### PR TITLE
Update set_baseline wait duration

### DIFF
--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -105,7 +105,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .number            = PROFILE_NUMBER_IAQ_SET_BASELINE,
-    .duration_us       = 1000,
+    .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
     .command           = { .buf = {0x20, 0x1e} },

--- a/sgpc3/sgpc3_featureset.c
+++ b/sgpc3/sgpc3_featureset.c
@@ -143,7 +143,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .number            = PROFILE_NUMBER_IAQ_SET_BASELINE,
-    .duration_us       = 1000,
+    .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
     .command           = { .buf = {0x20, 0x1e} },


### PR DESCRIPTION
The datasheet specifies a safe 10ms (max) waiting time after set_baseline.