### PR TITLE
Drop SGP signal scaling

### DIFF
--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -556,23 +556,19 @@ s16 sgp_measure_co2_eq_blocking_read(u16 *co2_eq_ppm) {
  * sgp_measure_signals_blocking_read() - Measure signals
  * The profile is executed synchronously.
  *
- * @scaled_ethanol_signal: Output variable for the ethanol signal
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
- * @scaled_h2_signal: Output variable for the h2 signal
- *                    The signal is scaled by factor 512. Divide the scaled
- *                    value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for the ethanol signal
+ * @h2_signal: Output variable for the h2 signal
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_measure_signals_blocking_read(u16 *scaled_ethanol_signal,
-                                      u16 *scaled_h2_signal) {
+s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal,
+                                      u16 *h2_signal) {
 
     if (sgp_run_profile_by_number(PROFILE_NUMBER_MEASURE_SIGNALS) == STATUS_FAIL)
         return STATUS_FAIL;
 
-    *scaled_ethanol_signal = client_data.word_buf[0];
-    *scaled_h2_signal = client_data.word_buf[1];
+    *ethanol_signal = client_data.word_buf[0];
+    *h2_signal = client_data.word_buf[1];
 
     return STATUS_OK;
 }
@@ -606,16 +602,12 @@ s16 sgp_measure_signals(void) {
  * This command can only be exectued after a measurement started with
  * sgp_measure_signals and has finished.
  *
- * @scaled_ethanol_signal: Output variable for ethanol signal.
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
- * @scaled_h2_signal: Output variable for h2 signal.
- *                    The signal is scaled by factor 512. Divide the scaled
- *                    value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for ethanol signal.
+ * @h2_signal: Output variable for h2 signal.
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_read_signals(u16 *scaled_ethanol_signal, u16 *scaled_h2_signal) {
+s16 sgp_read_signals(u16 *ethanol_signal, u16 *h2_signal) {
     const struct sgp_profile *profile;
 
     profile = sgp_get_profile_by_number(PROFILE_NUMBER_MEASURE_SIGNALS);
@@ -625,8 +617,8 @@ s16 sgp_read_signals(u16 *scaled_ethanol_signal, u16 *scaled_h2_signal) {
     if (read_measurement(profile) == STATUS_FAIL)
         return STATUS_FAIL;
 
-    *scaled_ethanol_signal = client_data.word_buf[0];
-    *scaled_h2_signal = client_data.word_buf[1];
+    *ethanol_signal = client_data.word_buf[0];
+    *h2_signal = client_data.word_buf[1];
 
     return STATUS_OK;
 }

--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -35,7 +35,7 @@
 #include "sgp30.h"
 
 
-#define SGP_DRV_VERSION_STR             "2.4.0"
+#define SGP_DRV_VERSION_STR             "3.0.0"
 #define SGP_RAM_WORDS                   4
 #define SGP_BUFFER_SIZE                 ((SGP_RAM_WORDS + 2) * \
                                          (SGP_WORD_LEN + CRC8_LEN))

--- a/sgp30/sgp30.h
+++ b/sgp30/sgp30.h
@@ -61,10 +61,10 @@ s16 sgp_measure_co2_eq_blocking_read(u16 *co2_eq_ppm);
 s16 sgp_measure_co2_eq(void);
 s16 sgp_read_co2_eq(u16 *co2_eq_ppm);
 
-s16 sgp_measure_signals_blocking_read(u16 *scaled_ethanol_signal,
-                                      u16 *scaled_h2_signal);
+s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal,
+                                      u16 *h2_signal);
 s16 sgp_measure_signals(void);
-s16 sgp_read_signals(u16 *scaled_ethanol_signal, u16 *scaled_h2_signal);
+s16 sgp_read_signals(u16 *ethanol_signal, u16 *h2_signal);
 
 s16 sgp_measure_test(u16 *test_result);
 

--- a/sgp30/sgp30_example_usage.c
+++ b/sgp30/sgp30_example_usage.c
@@ -43,7 +43,7 @@ int main(void) {
     s16 err;
     u16 tvoc_ppb, co2_eq_ppm;
     u32 iaq_baseline;
-    u16 scaled_ethanol_signal, scaled_h2_signal;
+    u16 ethanol_signal, h2_signal;
 
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
@@ -54,15 +54,12 @@ int main(void) {
 
 
     /* Read gas signals */
-    err = sgp_measure_signals_blocking_read(&scaled_ethanol_signal,
-                                            &scaled_h2_signal);
+    err = sgp_measure_signals_blocking_read(&ethanol_signal,
+                                            &h2_signal);
     if (err == STATUS_OK) {
-        /* Print ethanol signal with floating point support */
-        /* printf("Ethanol signal: %f\n", scaled_ethanol_signal / 512.0f); */
-
-        /* Print H2 signal without floating point support */
-        /* printf("H2 signal: %u.%09llu\n", scaled_h2_signal >> 9,
-         *          ((scaled_h2_signal & 0x01ff) * (u64)1000000000) >> 9); */
+        /* Print ethanol signal and h2 signal */
+        /* printf("Ethanol signal: %u\n", ethanol_signal); */
+        /* printf("H2 signal: %u\n", h2_signal); */
     } else {
         /* printf("error reading signals\n"); */
     }

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -35,7 +35,7 @@
 #include "sgpc3.h"
 
 
-#define SGP_DRV_VERSION_STR             "2.5.0"
+#define SGP_DRV_VERSION_STR             "3.0.0"
 #define SGP_RAM_WORDS                   4
 #define SGP_BUFFER_SIZE                 ((SGP_RAM_WORDS + 2) * \
                                          (SGP_WORD_LEN + CRC8_LEN))

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -507,18 +507,16 @@ s16 sgp_measure_tvoc_blocking_read(u16 *tvoc_ppb) {
  * sgp_measure_signals_blocking_read() - Measure signals
  * The profile is executed synchronously.
  *
- * @scaled_ethanol_signal: Output variable for the ethanol signal
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for the ethanol signal
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_measure_signals_blocking_read(u16 *scaled_ethanol_signal) {
+s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal) {
 
     if (sgp_run_profile_by_number(PROFILE_NUMBER_MEASURE_SIGNALS) == STATUS_FAIL)
         return STATUS_FAIL;
 
-    *scaled_ethanol_signal = client_data.word_buf[0];
+    *ethanol_signal = client_data.word_buf[0];
 
     return STATUS_OK;
 }
@@ -552,13 +550,11 @@ s16 sgp_measure_signals(void) {
  * This command can only be exectued after a measurement has been started with
  * sgp_measure_signals and has finished.
  *
- * @scaled_ethanol_signal: Output variable for ethanol signal.
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for ethanol signal.
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_read_signals(u16 *scaled_ethanol_signal) {
+s16 sgp_read_signals(u16 *ethanol_signal) {
     const struct sgp_profile *profile;
 
     profile = sgp_get_profile_by_number(PROFILE_NUMBER_MEASURE_SIGNALS);
@@ -568,7 +564,7 @@ s16 sgp_read_signals(u16 *scaled_ethanol_signal) {
     if (read_measurement(profile) == STATUS_FAIL)
         return STATUS_FAIL;
 
-    *scaled_ethanol_signal = client_data.word_buf[0];
+    *ethanol_signal = client_data.word_buf[0];
 
     return STATUS_OK;
 }
@@ -579,19 +575,17 @@ s16 sgp_read_signals(u16 *scaled_ethanol_signal) {
  * The profile is executed synchronously.
  *
  * @tvoc_ppb:              The tVOC ppb value will be written to this location
- * @scaled_ethanol_signal: Output variable for the ethanol signal
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for the ethanol signal
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *scaled_ethanol_signal) {
+s16 sgp_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *ethanol_signal) {
 
     if (sgp_run_profile_by_number(PROFILE_NUMBER_MEASURE_RAW) == STATUS_FAIL)
         return STATUS_FAIL;
 
     *tvoc_ppb = client_data.word_buf[0];
-    *scaled_ethanol_signal = client_data.word_buf[1];
+    *ethanol_signal = client_data.word_buf[1];
 
     return STATUS_OK;
 }
@@ -626,13 +620,11 @@ s16 sgp_measure_raw(void) {
  * sgp_measure_raw and has finished.
  *
  * @tvoc_ppb:              The tVOC ppb value will be written to this location
- * @scaled_ethanol_signal: Output variable for ethanol signal.
- *                         The signal is scaled by factor 512. Divide the scaled
- *                         value by 512 to get the real signal.
+ * @ethanol_signal: Output variable for ethanol signal.
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp_read_raw(u16 *tvoc_ppb, u16 *scaled_ethanol_signal) {
+s16 sgp_read_raw(u16 *tvoc_ppb, u16 *ethanol_signal) {
     const struct sgp_profile *profile;
 
     profile = sgp_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW);
@@ -643,7 +635,7 @@ s16 sgp_read_raw(u16 *tvoc_ppb, u16 *scaled_ethanol_signal) {
         return STATUS_FAIL;
 
     *tvoc_ppb = client_data.word_buf[0];
-    *scaled_ethanol_signal = client_data.word_buf[1];
+    *ethanol_signal = client_data.word_buf[1];
 
     return STATUS_OK;
 }

--- a/sgpc3/sgpc3.h
+++ b/sgpc3/sgpc3.h
@@ -62,13 +62,13 @@ s16 sgp_measure_tvoc_blocking_read(u16 *tvoc_ppb);
 s16 sgp_measure_tvoc(void);
 s16 sgp_read_tvoc(u16 *tvoc_ppb);
 
-s16 sgp_measure_signals_blocking_read(u16 *scaled_ethanol_signal);
+s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal);
 s16 sgp_measure_signals(void);
-s16 sgp_read_signals(u16 *scaled_ethanol_signal);
+s16 sgp_read_signals(u16 *ethanol_signal);
 
-s16 sgp_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *scaled_ethanol_signal);
+s16 sgp_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *ethanol_signal);
 s16 sgp_measure_raw(void);
-s16 sgp_read_raw(u16 *tvoc_ppb, u16 *scaled_ethanol_signal);
+s16 sgp_read_raw(u16 *tvoc_ppb, u16 *ethanol_signal);
 
 s16 sgp_set_power_mode(u16 power_mode);
 s16 sgp_set_absolute_humidity(u32 absolute_humidity);

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -43,7 +43,7 @@ int main(void) {
     s16 err;
     u16 tvoc_ppb;
     u16 iaq_baseline;
-    u16 scaled_ethanol_signal;
+    u16 ethanol_signal;
 
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
@@ -59,16 +59,11 @@ int main(void) {
      * restoring it after with sgp_get_iaq_baseline / sgp_set_iaq_baseline.
      * If a recent baseline is not available, reset it using
      * sgp_iaq_init_continuous prior to running IAQ measurements.  */
-    err = sgp_measure_signals_blocking_read(&scaled_ethanol_signal);
+    err = sgp_measure_signals_blocking_read(&ethanol_signal);
 
     if (err == STATUS_OK) {
-        /* Print ethanol signal with floating point support */
-        /* printf("Ethanol signal: %f\n", scaled_ethanol_signal / 512.0f); */
-
-        /* Print ethanol signal without floating point support */
-        /* printf("ethanol signal: %u.%09llu\n", scaled_ethanol_signal >> 9,
-         *          ((scaled_ethanol_signal & 0x01ff) * (u64)1000000000) >> 9);
-         */
+        /* Print ethanol signal */
+        /* printf("Ethanol signal: %u\n", ethanol_signal); */
     } else {
         /* printf("error reading signals\n"); */
     }


### PR DESCRIPTION
We do not scale ethanol and h2 signals by 512 anymore to avoid
unnecessary computations