### PR TITLE
Fix version check disabling sgp_set_absolute_humidity

### DIFF
--- a/sgp-common/sgp_featureset.h
+++ b/sgp-common/sgp_featureset.h
@@ -76,7 +76,7 @@ extern const u8 PROFILE_NUMBER_SET_POWER_MODE;
 /** Check if the chip's featureset is newer than or equal to the required one */
 #define SGP_REQUIRE_FS(chip_fs, major, minor)  ( \
         ( /* major version equal, minor version upwards compatible */ \
-          (((chip_fs) & 0x00E0) == (major)) && \
+          ((((chip_fs) & 0x00E0) >> 5) == (major)) && \
           (((chip_fs) & 0x001F) >= (minor)) \
         ))
 


### PR DESCRIPTION
Fix the version check macro `SGP_REQUIRE_FS` that failed to shift the
major version bits down prior to the comparison.

This caused `sgp_set_absolute_humidity` to constantly fail on the
SGP30.

Based on patch by GitHub user vrubel. Thanks.
https://github.com/Sensirion/embedded-sgp/pull/31