### PR TITLE
Remove -Werror build flag

### DIFF
--- a/sgp30/Makefile
+++ b/sgp30/Makefile
@@ -3,7 +3,7 @@ sgp_common_dir := ../sgp-common
 sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
 hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
 
-CFLAGS := -Os -Wall -Werror -I. -I${sensirion_common_dir} -I${sgp_common_dir}
+CFLAGS := -Os -Wall -I. -I${sensirion_common_dir} -I${sgp_common_dir}
 
 sensirion_common_objects := sensirion_common.o
 sgp30_binaries := sgp30_example_usage_hw_i2c sgp30_example_usage_sw_i2c

--- a/sgpc3/Makefile
+++ b/sgpc3/Makefile
@@ -3,7 +3,7 @@ sgp_common_dir := ../sgp-common
 sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
 hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
 
-CFLAGS := -Wall -Werror -I. -I${sensirion_common_dir} -I${sgp_common_dir}
+CFLAGS := -Wall -I. -I${sensirion_common_dir} -I${sgp_common_dir}
 
 sensirion_common_objects := sensirion_common.o
 sgpc3_binaries := sgpc3_example_usage_hw_i2c sgpc3_example_usage_sw_i2c

--- a/svm30/Makefile
+++ b/svm30/Makefile
@@ -19,8 +19,8 @@ sensirion_common_sources := ${sensirion_common_dir}/sensirion_arch_config.h \
 sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
 hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
 
-CFLAGS := -Os -Wall -Werror -I. -I${sensirion_common_dir} \
-          -I${sgp_source_dir} -I${sgp_common_dir} -I${sht_common_dir}
+CFLAGS := -Os -Wall -I. -I${sensirion_common_dir} -I${sgp_source_dir} \
+          -I${sgp_common_dir} -I${sht_common_dir}
 
 svm30_binaries := svm30_example_usage_hw_i2c svm30_example_usage_sw_i2c
 svm_binaries += ${svm30_binaries}


### PR DESCRIPTION
Remove -Werror build flag to avoid breaking builds due to future
compiler warnings or warnings due to different compilers...