### PR TITLE
Sensirion common send

### DIFF
--- a/sgp-common/sgp_featureset.h
+++ b/sgp-common/sgp_featureset.h
@@ -80,11 +80,6 @@ extern const u8 PROFILE_NUMBER_SET_POWER_MODE;
           (((chip_fs) & 0x001F) >= (minor)) \
         ))
 
-typedef union {
-    u16 words[SGP_COMMAND_LEN / SGP_WORD_LEN]; /* enforce u16 alignment */
-    u8 buf[SGP_COMMAND_LEN];
-} sgp_command;
-
 struct sgp_signal {
     u16(*conversion_function)(u16);
     char name[NAME_SIZE];
@@ -92,13 +87,13 @@ struct sgp_signal {
 
 struct sgp_profile {
     /* expected duration of measurement, i.e., when to return for data */
-    u32 duration_us;
+    const u32 duration_us;
     /* signals */
     const struct sgp_signal **signals;
-    u16 number_of_signals;
-    u8 number;
-    const sgp_command command;
-    char name[NAME_SIZE];
+    const u16 number_of_signals;
+    const u16 command;
+    const u8 number;
+    const char name[NAME_SIZE];
 };
 
 struct sgp_otp_featureset {

--- a/sgp30/sgp30_example_usage.c
+++ b/sgp30/sgp30_example_usage.c
@@ -49,6 +49,7 @@ int main(void) {
      * a sensor. */
     while (sgp_probe() != STATUS_OK) {
         /* printf("SGP sensor probing failed\n"); */
+        /* sleep(1); */
     }
     /* printf("SGP sensor probing successful\n"); */
 

--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -86,7 +86,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x03} },
+    .command           = 0x2003,
     .name              = "iaq_init",
 };
 
@@ -95,7 +95,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE9 = {
     .duration_us       = 50000,
     .signals           = SGP_PROFILE_IAQ_MEASURE_SIGNALS9,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_SIGNALS9),
-    .command           = { .buf = {0x20, 0x08} },
+    .command           = 0x2008,
     .name              = "iaq_measure",
 };
 
@@ -104,7 +104,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_FACTORY_BASELINE = {
     .duration_us       = 10000,
     .signals           = SGP_PROFILE_IAQ_GET_TVOC_FACTORY_BASELINE_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_TVOC_FACTORY_BASELINE_SIGNALS),
-    .command           = { .buf = {0x20, 0xb3} },
+    .command           = 0x20b3,
     .name              = "iaq_get_tvoc_factory_baseline",
 };
 
@@ -113,7 +113,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_SET_TVOC_BASELINE = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x77} },
+    .command           = 0x2077,
     .name              = "iaq_set_tvoc_baseline",
 };
 
@@ -122,7 +122,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
     .duration_us       = 10000,
     .signals           = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
-    .command           = { .buf = {0x20, 0x15} },
+    .command           = 0x2015,
     .name              = "iaq_get_baseline",
 };
 
@@ -131,7 +131,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x1e} },
+    .command           = 0x201e,
     .name              = "iaq_set_baseline",
 };
 
@@ -140,7 +140,7 @@ static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS9 = {
     .duration_us       = 200000,
     .signals           = SGP_PROFILE_MEASURE_SIGNALS_SIGNALS9,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_SIGNALS_SIGNALS9),
-    .command           = { .buf = {0x20, 0x50} },
+    .command           = 0x2050,
     .name              = "measure_signals",
 };
 
@@ -149,7 +149,7 @@ static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x61} },
+    .command           = 0x2061,
     .name              = "set_absolute_humidity",
 };
 

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -92,7 +92,7 @@ int main(void) {
         }
 
         /* Persist the current baseline every hour */
-        if (++i % 3600 == 3599) {
+        if (++i % 1800 == 1799) {
             err = sgp_get_iaq_baseline(&iaq_baseline);
             if (err == STATUS_OK) {
                 /* IMPLEMENT: store baseline to presistent storage */

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -49,6 +49,7 @@ int main(void) {
      * a sensor. */
     while (sgp_probe() != STATUS_OK) {
         /* printf("SGP sensor probing failed\n"); */
+        /* sleep(1); */
     }
     /* printf("SGP sensor probing successful\n"); */
 

--- a/sgpc3/sgpc3_featureset.c
+++ b/sgpc3/sgpc3_featureset.c
@@ -84,7 +84,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT64 = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x03} },
+    .command           = 0x2003,
     .name              = "iaq_init64",
 };
 
@@ -93,7 +93,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT0 = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x89} },
+    .command           = 0x2089,
     .name              = "iaq_init0",
 };
 
@@ -102,7 +102,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT16 = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x24} },
+    .command           = 0x2024,
     .name              = "iaq_init16",
 };
 
@@ -111,7 +111,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT184 = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x6a} },
+    .command           = 0x206a,
     .name              = "iaq_init184",
 };
 
@@ -120,7 +120,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_INIT_CONTINUOUS = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0xae} },
+    .command           = 0x20ae,
     .name              = "iaq_init_continuous",
 };
 
@@ -129,7 +129,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE = {
     .duration_us       = 50000,
     .signals           = SGP_PROFILE_IAQ_MEASURE_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_SIGNALS),
-    .command           = { .buf = {0x20, 0x08} },
+    .command           = 0x2008,
     .name              = "iaq_measure",
 };
 
@@ -138,7 +138,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
     .duration_us       = 10000,
     .signals           = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
-    .command           = { .buf = {0x20, 0x15} },
+    .command           = 0x2015,
     .name              = "iaq_get_baseline",
 };
 
@@ -147,7 +147,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x1e} },
+    .command           = 0x201e,
     .name              = "iaq_set_baseline",
 };
 
@@ -156,7 +156,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_FACTORY_BASELINE = {
     .duration_us       = 10000,
     .signals           = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
-    .command           = { .buf = {0x20, 0xb3} },
+    .command           = 0x20b3,
     .name              = "iaq_get_tvoc_factory_baseline",
 };
 
@@ -165,7 +165,7 @@ static const struct sgp_profile SGP_PROFILE_MEASURE_ETOH_SIGNAL = {
     .duration_us       = 50000,
     .signals           = SGP_PROFILE_MEASURE_ETOH_SIGNAL_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_ETOH_SIGNAL_SIGNALS),
-    .command           = { .buf = {0x20, 0x4d} },
+    .command           = 0x204d,
     .name              = "measure_etoh_signal",
 };
 
@@ -174,7 +174,7 @@ static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE_RAW = {
     .duration_us       = 50000,
     .signals           = SGP_PROFILE_IAQ_MEASURE_RAW_SIGNALS,
     .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_RAW_SIGNALS),
-    .command           = { .buf = {0x20, 0x46} },
+    .command           = 0x2046,
     .name              = "iaq_measure_raw",
 };
 
@@ -183,7 +183,7 @@ static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x61} },
+    .command           = 0x2061,
     .name              = "set_absolute_humidity",
 };
 
@@ -192,7 +192,7 @@ static const struct sgp_profile SGP_PROFILE_SET_POWER_MODE = {
     .duration_us       = 10000,
     .signals           = NULL,
     .number_of_signals = 0,
-    .command           = { .buf = {0x20, 0x9f} },
+    .command           = 0x209f,
     .name              = "set_power_mode",
 };
 


### PR DESCRIPTION
* Use unified Sensirion Common code for i2c coms
* Fix sgpc3 example: store baseline every 1h
* Example usage: Add sleep between failed probes