### PR TITLE
Rename methods prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * [`changed]` Rename factory baseline to inceptive baseline
+ * [`changed`] Prefix all methods with `sgp30_` / `sgpc3_` instead of `sgp_`
  * [`fixed`] Feature set check for SVM30
  * [`fixed`] Rebuild when example source code changed
 

--- a/sgp30/sgp30.h
+++ b/sgp30/sgp30.h
@@ -38,39 +38,39 @@
 extern "C" {
 #endif
 
-s16 sgp_probe(void);
-s16 sgp_iaq_init(void);
+s16 sgp30_probe(void);
+s16 sgp30_iaq_init(void);
 
-const char *sgp_get_driver_version(void);
-u8 sgp_get_configured_address(void);
-s16 sgp_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
-s16 sgp_get_serial_id(u64 *serial_id);
+const char *sgp30_get_driver_version(void);
+u8 sgp30_get_configured_address(void);
+s16 sgp30_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
+s16 sgp30_get_serial_id(u64 *serial_id);
 
-s16 sgp_get_iaq_baseline(u32 *baseline);
-s16 sgp_set_iaq_baseline(u32 baseline);
-s16 sgp_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
-s16 sgp_set_tvoc_baseline(u16 tvoc_baseline);
+s16 sgp30_get_iaq_baseline(u32 *baseline);
+s16 sgp30_set_iaq_baseline(u32 baseline);
+s16 sgp30_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
+s16 sgp30_set_tvoc_baseline(u16 tvoc_baseline);
 
-s16 sgp_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm);
-s16 sgp_measure_iaq(void);
-s16 sgp_read_iaq(u16 *tvoc_ppb, u16 *co2_eq_ppm);
+s16 sgp30_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm);
+s16 sgp30_measure_iaq(void);
+s16 sgp30_read_iaq(u16 *tvoc_ppb, u16 *co2_eq_ppm);
 
-s16 sgp_measure_tvoc_blocking_read(u16 *tvoc_ppb);
-s16 sgp_measure_tvoc(void);
-s16 sgp_read_tvoc(u16 *tvoc_ppb);
+s16 sgp30_measure_tvoc_blocking_read(u16 *tvoc_ppb);
+s16 sgp30_measure_tvoc(void);
+s16 sgp30_read_tvoc(u16 *tvoc_ppb);
 
-s16 sgp_measure_co2_eq_blocking_read(u16 *co2_eq_ppm);
-s16 sgp_measure_co2_eq(void);
-s16 sgp_read_co2_eq(u16 *co2_eq_ppm);
+s16 sgp30_measure_co2_eq_blocking_read(u16 *co2_eq_ppm);
+s16 sgp30_measure_co2_eq(void);
+s16 sgp30_read_co2_eq(u16 *co2_eq_ppm);
 
-s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal,
+s16 sgp30_measure_signals_blocking_read(u16 *ethanol_signal,
                                       u16 *h2_signal);
-s16 sgp_measure_signals(void);
-s16 sgp_read_signals(u16 *ethanol_signal, u16 *h2_signal);
+s16 sgp30_measure_signals(void);
+s16 sgp30_read_signals(u16 *ethanol_signal, u16 *h2_signal);
 
-s16 sgp_measure_test(u16 *test_result);
+s16 sgp30_measure_test(u16 *test_result);
 
-s16 sgp_set_absolute_humidity(u32 absolute_humidity);
+s16 sgp30_set_absolute_humidity(u32 absolute_humidity);
 
 #ifdef __cplusplus
 }

--- a/sgp30/sgp30_example_usage.c
+++ b/sgp30/sgp30_example_usage.c
@@ -47,7 +47,7 @@ int main(void) {
 
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
-    while (sgp_probe() != STATUS_OK) {
+    while (sgp30_probe() != STATUS_OK) {
         /* printf("SGP sensor probing failed\n"); */
         /* sleep(1); */
     }
@@ -55,7 +55,7 @@ int main(void) {
 
 
     /* Read gas signals */
-    err = sgp_measure_signals_blocking_read(&ethanol_signal,
+    err = sgp30_measure_signals_blocking_read(&ethanol_signal,
                                             &h2_signal);
     if (err == STATUS_OK) {
         /* Print ethanol signal and h2 signal */
@@ -69,12 +69,12 @@ int main(void) {
     /* Consider the two cases (A) and (B):
      * (A) If no baseline is available or the most recent baseline is more than
      *     one week old, it must discarded. A new baseline is found with
-     *     sgp_iaq_init() */
-    err = sgp_iaq_init();
-    /* (B) If a recent baseline is available, set it after sgp_iaq_init() for
+     *     sgp30_iaq_init() */
+    err = sgp30_iaq_init();
+    /* (B) If a recent baseline is available, set it after sgp30_iaq_init() for
      * faster start-up */
     /* IMPLEMENT: retrieve iaq_baseline from presistent storage;
-     * err = sgp_set_iaq_baseline(iaq_baseline);
+     * err = sgp30_set_iaq_baseline(iaq_baseline);
      */
 
     /* Run periodic IAQ measurements at defined intervals */
@@ -82,10 +82,10 @@ int main(void) {
         /*
         * IMPLEMENT: get absolute humidity to enable humidity compensation
         * u32 ah = get_absolute_humidity(); // absolute humidity in mg/m^3
-        * sgp_set_absolute_humidity(ah);
+        * sgp30_set_absolute_humidity(ah);
         */
 
-        err = sgp_measure_iaq_blocking_read(&tvoc_ppb, &co2_eq_ppm);
+        err = sgp30_measure_iaq_blocking_read(&tvoc_ppb, &co2_eq_ppm);
         if (err == STATUS_OK) {
             /* printf("tVOC  Concentration: %dppb\n", tvoc_ppb);
              * printf("CO2eq Concentration: %dppm\n", co2_eq_ppm);
@@ -96,7 +96,7 @@ int main(void) {
 
         /* Persist the current baseline every hour */
         if (++i % 3600 == 3599) {
-            err = sgp_get_iaq_baseline(&iaq_baseline);
+            err = sgp30_get_iaq_baseline(&iaq_baseline);
             if (err == STATUS_OK) {
                 /* IMPLEMENT: store baseline to presistent storage */
             }

--- a/sgpc3/sgpc3.h
+++ b/sgpc3/sgpc3.h
@@ -38,42 +38,42 @@
 extern "C" {
 #endif
 
-s16 sgp_probe(void);
-s16 sgp_iaq_init(void);
-s16 sgp_iaq_init0(void);
-s16 sgp_iaq_init16(void);
-s16 sgp_iaq_init64(void);
-s16 sgp_iaq_init184(void);
-s16 sgp_iaq_init_continuous(void);
+s16 sgpc3_probe(void);
+s16 sgpc3_iaq_init(void);
+s16 sgpc3_iaq_init0(void);
+s16 sgpc3_iaq_init16(void);
+s16 sgpc3_iaq_init64(void);
+s16 sgpc3_iaq_init184(void);
+s16 sgpc3_iaq_init_continuous(void);
 
-const char *sgp_get_driver_version(void);
-u8 sgp_get_configured_address(void);
-s16 sgp_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
-s16 sgp_get_serial_id(u64 *serial_id);
+const char *sgpc3_get_driver_version(void);
+u8 sgpc3_get_configured_address(void);
+s16 sgpc3_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
+s16 sgpc3_get_serial_id(u64 *serial_id);
 
-s16 sgp_get_iaq_baseline(u16 *baseline);
-s16 sgp_set_iaq_baseline(u16 baseline);
-s16 sgp_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
+s16 sgpc3_get_iaq_baseline(u16 *baseline);
+s16 sgpc3_set_iaq_baseline(u16 baseline);
+s16 sgpc3_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
 
-s16 sgp_measure_iaq_blocking_read(u16 *tvoc_ppb);
-s16 sgp_measure_iaq(void);
-s16 sgp_read_iaq(u16 *tvoc_ppb);
+s16 sgpc3_measure_iaq_blocking_read(u16 *tvoc_ppb);
+s16 sgpc3_measure_iaq(void);
+s16 sgpc3_read_iaq(u16 *tvoc_ppb);
 
-s16 sgp_measure_tvoc_blocking_read(u16 *tvoc_ppb);
-s16 sgp_measure_tvoc(void);
-s16 sgp_read_tvoc(u16 *tvoc_ppb);
+s16 sgpc3_measure_tvoc_blocking_read(u16 *tvoc_ppb);
+s16 sgpc3_measure_tvoc(void);
+s16 sgpc3_read_tvoc(u16 *tvoc_ppb);
 
-s16 sgp_measure_signals_blocking_read(u16 *ethanol_signal);
-s16 sgp_measure_signals(void);
-s16 sgp_read_signals(u16 *ethanol_signal);
+s16 sgpc3_measure_signals_blocking_read(u16 *ethanol_signal);
+s16 sgpc3_measure_signals(void);
+s16 sgpc3_read_signals(u16 *ethanol_signal);
 
-s16 sgp_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *ethanol_signal);
-s16 sgp_measure_raw(void);
-s16 sgp_read_raw(u16 *tvoc_ppb, u16 *ethanol_signal);
+s16 sgpc3_measure_raw_blocking_read(u16 *tvoc_ppb, u16 *ethanol_signal);
+s16 sgpc3_measure_raw(void);
+s16 sgpc3_read_raw(u16 *tvoc_ppb, u16 *ethanol_signal);
 
-s16 sgp_set_power_mode(u16 power_mode);
-s16 sgp_set_absolute_humidity(u32 absolute_humidity);
-s16 sgp_measure_test(u16 *test_result);
+s16 sgpc3_set_power_mode(u16 power_mode);
+s16 sgpc3_set_absolute_humidity(u32 absolute_humidity);
+s16 sgpc3_measure_test(u16 *test_result);
 
 #ifdef __cplusplus
 }

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -47,7 +47,7 @@ int main(void) {
 
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
-    while (sgp_probe() != STATUS_OK) {
+    while (sgpc3_probe() != STATUS_OK) {
         /* printf("SGP sensor probing failed\n"); */
         /* sleep(1); */
     }
@@ -57,10 +57,10 @@ int main(void) {
     /* Read signals.
      * Do not run measure_signals between IAQ measurements
      * (iaq, tVOC) without saving the baseline before the call and
-     * restoring it after with sgp_get_iaq_baseline / sgp_set_iaq_baseline.
+     * restoring it after with sgpc3_get_iaq_baseline / sgpc3_set_iaq_baseline.
      * If a recent baseline is not available, reset it using
-     * sgp_iaq_init_continuous prior to running IAQ measurements.  */
-    err = sgp_measure_signals_blocking_read(&ethanol_signal);
+     * sgpc3_iaq_init_continuous prior to running IAQ measurements.  */
+    err = sgpc3_measure_signals_blocking_read(&ethanol_signal);
 
     if (err == STATUS_OK) {
         /* Print ethanol signal */
@@ -72,12 +72,12 @@ int main(void) {
     /* Consider the two cases (A) and (B):
      * (A) If no baseline is available or the most recent baseline is more than
      *     one week old, it must discarded. A new baseline is found with
-     *     sgp_iaq_init_continuous() */
-    err = sgp_iaq_init_continuous();
+     *     sgpc3_iaq_init_continuous() */
+    err = sgpc3_iaq_init_continuous();
     /* (B) If a recent baseline is available, set it after
-     *      sgp_iaq_init_continuous() for faster start-up */
+     *      sgpc3_iaq_init_continuous() for faster start-up */
     /* IMPLEMENT: retrieve iaq_baseline from presistent storage;
-     * err = sgp_set_iaq_baseline(iaq_baseline);
+     * err = sgpc3_set_iaq_baseline(iaq_baseline);
      */
 
     /* IMPLEMENT: sleep for the desired accelerated warm-up duration */
@@ -85,7 +85,7 @@ int main(void) {
 
     /* Run periodic IAQ measurements at defined intervals */
     while (1) {
-        err = sgp_measure_iaq_blocking_read(&tvoc_ppb);
+        err = sgpc3_measure_iaq_blocking_read(&tvoc_ppb);
         if (err == STATUS_OK) {
             /* printf("tVOC  Concentration: %dppb\n", tvoc_ppb); */
         } else {
@@ -94,7 +94,7 @@ int main(void) {
 
         /* Persist the current baseline every hour */
         if (++i % 1800 == 1799) {
-            err = sgp_get_iaq_baseline(&iaq_baseline);
+            err = sgpc3_get_iaq_baseline(&iaq_baseline);
             if (err == STATUS_OK) {
                 /* IMPLEMENT: store baseline to presistent storage */
             }

--- a/svm30/svm30.c
+++ b/svm30/svm30.c
@@ -105,15 +105,15 @@ s16 svm_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm,
     if (err != STATUS_OK)
         return err;
 
-    sgp_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
+    sgp30_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
     if (SGP_REQUIRE_FS(sgp_feature_set, 1, 0)) {
         absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
-        sgp_set_absolute_humidity(absolute_humidity);
+        sgp30_set_absolute_humidity(absolute_humidity);
     }
 
     svm_compensate_rht(temperature, humidity);
 
-    err = sgp_measure_iaq_blocking_read(tvoc_ppb, co2_eq_ppm);
+    err = sgp30_measure_iaq_blocking_read(tvoc_ppb, co2_eq_ppm);
     if (err != STATUS_OK)
         return err;
 
@@ -144,13 +144,13 @@ s16 svm_measure_signals_blocking_read(u16 *ethanol_signal, u16 *h2_signal,
     if (err != STATUS_OK)
         return err;
 
-    sgp_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
+    sgp30_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
     if (SGP_REQUIRE_FS(sgp_feature_set, 1, 0)) {
         absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
-        sgp_set_absolute_humidity(absolute_humidity);
+        sgp30_set_absolute_humidity(absolute_humidity);
     }
 
-    err = sgp_measure_signals_blocking_read(ethanol_signal, h2_signal);
+    err = sgp30_measure_signals_blocking_read(ethanol_signal, h2_signal);
     if (err != STATUS_OK)
         return err;
 
@@ -160,7 +160,7 @@ s16 svm_measure_signals_blocking_read(u16 *ethanol_signal, u16 *h2_signal,
 /**
  * svm_probe() - check if an SVM30 module is available and initialize it
  *
- * This call aleady initializes the IAQ baselines (sgp_iaq_init())
+ * This call aleady initializes the IAQ baselines (sgp30_iaq_init())
  *
  * Return:  STATUS_OK on success.
  */
@@ -171,5 +171,5 @@ s16 svm_probe() {
     if (err != STATUS_OK)
         return err;
 
-    return sgp_probe();
+    return sgp30_probe();
 }

--- a/svm30/svm30_example_usage.c
+++ b/svm30/svm30_example_usage.c
@@ -56,7 +56,7 @@ int main(void) {
      * (A) If no baseline is available or the most recent baseline is more than
      *     one week old, it must discarded. A new baseline is found with
      *     sgp_iaq_init() */
-    err = sgp_iaq_init();
+    err = sgp30_iaq_init();
     /* (B) If a recent baseline is available, set it after sgp_iaq_init() for
      * faster start-up */
     /* IMPLEMENT: retrieve iaq_baseline from presistent storage;
@@ -79,7 +79,7 @@ int main(void) {
 
         /* Persist the current baseline every hour */
         if (++i % 3600 == 3599) {
-            err = sgp_get_iaq_baseline(&iaq_baseline);
+            err = sgp30_get_iaq_baseline(&iaq_baseline);
             if (err == STATUS_OK) {
                 /* IMPLEMENT: store baseline to presistent storage */
             }


### PR DESCRIPTION
This makes it possible to use both SGPC3 and SGP30 in the same project.
cc @winkj.