### PR TITLE
SGPC3: Rename occurrences of IAQ in comments to TVOC

### DIFF
--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -505,11 +505,11 @@ s16 sgpc3_read_tvoc_and_raw(u16 *tvoc_ppb, u16 *ethanol_raw_signal) {
 /**
  * sgpc3_get_tvoc_baseline() - read out the baseline from the chip
  *
- * The IAQ baseline should be retrieved and persisted for a faster sensor
+ * The TVOC baseline should be retrieved and persisted for a faster sensor
  * startup. See sgpc3_set_tvoc_baseline() for further documentation.
  *
  * A valid baseline value is only returned approx. 60min after a call to
- * sgpc3_iaq_init_preheat() when it is not followed by a call to
+ * sgpc3_tvoc_init_preheat() when it is not followed by a call to
  * sgpc3_set_tvoc_baseline() with a valid baseline.
  * This functions returns STATUS_FAIL if the baseline value is not valid.
  *
@@ -626,7 +626,7 @@ s16 sgpc3_set_absolute_humidity(u32 absolute_humidity) {
 /**
  * sgpc3_set_power_mode() - set the power mode
  *
- * The measurement interval for both IAQ and ethanol measurements changes
+ * The measurement interval for both TVOC and ethanol measurements changes
  * according to the power mode. See application notes for further
  * documentation.
  *
@@ -707,7 +707,7 @@ s16 sgpc3_get_serial_id(u64 *serial_id) {
 /**
  * sgpc3_tvoc_init_preheat() - reset the SGP's internal TVOC baselines and
  *                             run accelerated startup until the first
- *                             sgpc3_measure_iaq()
+ *                             sgpc3_measure_tvoc()
  *
  * Return:  STATUS_OK on success.
  */

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -85,7 +85,7 @@ int main(void) {
      * without saving the baseline before the call and
      * restoring it after with sgpc3_get_tvoc_baseline / sgpc3_set_tvoc_baseline.
      * If a recent baseline is not available, reset it using
-     * sgpc3_iaq_init_continuous prior to running tVOC measurements.  */
+     * sgpc3_tvoc_init_preheat prior to running tVOC measurements. */
     err = sgpc3_measure_raw_blocking_read(&ethanol_raw_signal);
 
     if (err == STATUS_OK) {
@@ -98,13 +98,13 @@ int main(void) {
     /* Consider the two cases (A) and (B):
      * (A) If no baseline is available or the most recent baseline is more than
      *     one week old, it must discarded. A new baseline is found with
-     *     sgpc3_iaq_init_continuous() */
+     *     sgpc3_tvoc_init_preheat() */
     if (feature_set_version >= 0x06) {
         err = sgpc3_tvoc_init_preheat();
         /* IMPLEMENT: sleep for the desired accelerated warm-up duration */
         sleep(64);
     } else {
-        /* feature sets older than 0x06 do not support iaq_init_continuous */
+        /* feature sets older than 0x06 do not support tvoc_init_preheat */
         err = sgpc3_tvoc_init_64s_fs5();
     }
     if (err == STATUS_OK) {
@@ -114,7 +114,7 @@ int main(void) {
     }
 
     /* (B) If a recent baseline is available, set it after
-     *      sgpc3_iaq_init_continuous() for faster start-up */
+     *      sgpc3_tvoc_init_preheat() for faster start-up */
     /* IMPLEMENT: retrieve tvoc_baseline from presistent storage;
      * err = sgpc3_set_tvoc_baseline(tvoc_baseline);
      */


### PR DESCRIPTION
Also fixes some references to old function names in the comments.