### PR TITLE
Automated type conversion

### DIFF
--- a/sgp-common/sgp_featureset.h
+++ b/sgp-common/sgp_featureset.h
@@ -48,16 +48,16 @@ extern "C" {
 #define PROFILE_NUMBER_IAQ_GET_BASELINE 2
 #define PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE 22
 #define PROFILE_NUMBER_IAQ_SET_BASELINE 3
-extern const u8 PROFILE_NUMBER_MEASURE_RAW_SIGNALS;
-extern const u8 PROFILE_NUMBER_MEASURE_RAW;
-extern const u8 PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY;
-extern const u8 PROFILE_NUMBER_IAQ_INIT0;
-extern const u8 PROFILE_NUMBER_IAQ_INIT16;
-extern const u8 PROFILE_NUMBER_IAQ_INIT64;
-extern const u8 PROFILE_NUMBER_IAQ_INIT184;
-extern const u8 PROFILE_NUMBER_IAQ_INIT_CONTINUOUS;
-extern const u8 PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE;
-extern const u8 PROFILE_NUMBER_SET_POWER_MODE;
+extern const uint8_t PROFILE_NUMBER_MEASURE_RAW_SIGNALS;
+extern const uint8_t PROFILE_NUMBER_MEASURE_RAW;
+extern const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY;
+extern const uint8_t PROFILE_NUMBER_IAQ_INIT0;
+extern const uint8_t PROFILE_NUMBER_IAQ_INIT16;
+extern const uint8_t PROFILE_NUMBER_IAQ_INIT64;
+extern const uint8_t PROFILE_NUMBER_IAQ_INIT184;
+extern const uint8_t PROFILE_NUMBER_IAQ_INIT_CONTINUOUS;
+extern const uint8_t PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE;
+extern const uint8_t PROFILE_NUMBER_SET_POWER_MODE;
 
 /**
  * Check if chip featureset is compatible with driver featureset:
@@ -80,31 +80,31 @@ extern const u8 PROFILE_NUMBER_SET_POWER_MODE;
       (((chip_fs)&0x001F) >= (minor))))
 
 struct sgp_signal {
-    u16 (*conversion_function)(u16);
+    uint16_t (*conversion_function)(uint16_t);
     char name[NAME_SIZE];
 };
 
 struct sgp_profile {
     /* expected duration of measurement, i.e., when to return for data */
-    const u32 duration_us;
+    const uint32_t duration_us;
     /* signals */
     const struct sgp_signal **signals;
-    const u16 number_of_signals;
-    const u16 command;
-    const u8 number;
+    const uint16_t number_of_signals;
+    const uint16_t command;
+    const uint8_t number;
     const char name[NAME_SIZE];
 };
 
 struct sgp_otp_featureset {
     const struct sgp_profile **profiles;
-    u16 number_of_profiles;
-    const u16 *supported_featureset_versions;
-    u16 number_of_supported_featureset_versions;
+    uint16_t number_of_profiles;
+    const uint16_t *supported_featureset_versions;
+    uint16_t number_of_supported_featureset_versions;
 };
 
 struct sgp_otp_supported_featuresets {
     const struct sgp_otp_featureset **featuresets;
-    u16 number_of_supported_featuresets;
+    uint16_t number_of_supported_featuresets;
 };
 
 extern const struct sgp_otp_supported_featuresets sgp_supported_featuresets;

--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -43,26 +43,26 @@
 #define SGP_VALID_IAQ_BASELINE(b) ((b) != 0)
 
 #ifdef SGP_ADDRESS
-static const u8 SGP_I2C_ADDRESS = SGP_ADDRESS;
+static const uint8_t SGP_I2C_ADDRESS = SGP_ADDRESS;
 #else
-static const u8 SGP_I2C_ADDRESS = 0x58;
+static const uint8_t SGP_I2C_ADDRESS = 0x58;
 #endif
 
 /* command and constants for reading the serial ID */
 #define SGP_CMD_GET_SERIAL_ID_DURATION_US 500
 #define SGP_CMD_GET_SERIAL_ID_WORDS 3
-static const u16 sgp30_cmd_get_serial_id = 0x3682;
+static const uint16_t sgp30_cmd_get_serial_id = 0x3682;
 
 /* command and constants for reading the featureset version */
 #define SGP_CMD_GET_FEATURESET_DURATION_US 1000
 #define SGP_CMD_GET_FEATURESET_WORDS 1
-static const u16 sgp30_cmd_get_featureset = 0x202f;
+static const uint16_t sgp30_cmd_get_featureset = 0x202f;
 
 /* command and constants for on-chip self-test */
 #define SGP_CMD_MEASURE_TEST_DURATION_US 220000
 #define SGP_CMD_MEASURE_TEST_WORDS 1
 #define SGP_CMD_MEASURE_TEST_OK 0xd400
-static const u16 sgp30_cmd_measure_test = 0x2032;
+static const uint16_t sgp30_cmd_measure_test = 0x2032;
 
 static const struct sgp_otp_featureset sgp30_features_unknown = {
     .profiles = NULL,
@@ -72,8 +72,8 @@ static const struct sgp_otp_featureset sgp30_features_unknown = {
 enum sgp30_state_code { WAIT_STATE, MEASURING_PROFILE_STATE };
 
 struct sgp30_info {
-    u64 serial_id;
-    u16 feature_set_version;
+    uint64_t serial_id;
+    uint16_t feature_set_version;
 };
 
 static struct sgp30_data {
@@ -81,8 +81,8 @@ static struct sgp30_data {
     struct sgp30_info info;
     const struct sgp_otp_featureset *otp_features;
     union {
-        u16 words[SGP_BUFFER_WORDS];
-        u64 u64_value;
+        uint16_t words[SGP_BUFFER_WORDS];
+        uint64_t u64_value;
     } buffer;
 } client_data;
 
@@ -92,11 +92,11 @@ static struct sgp30_data {
  * @profile:    The profile
  */
 static void unpack_signals(const struct sgp_profile *profile) {
-    s16 i, j;
+    int16_t i, j;
     const struct sgp_signal *signal;
-    u16 data_words = profile->number_of_signals;
-    u16 word_buf[data_words];
-    u16 value;
+    uint16_t data_words = profile->number_of_signals;
+    uint16_t word_buf[data_words];
+    uint16_t value;
 
     /* copy buffer */
     for (i = 0; i < data_words; i++)
@@ -119,8 +119,8 @@ static void unpack_signals(const struct sgp_profile *profile) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-static s16 read_measurement(const struct sgp_profile *profile) {
-    s16 ret;
+static int16_t read_measurement(const struct sgp_profile *profile) {
+    int16_t ret;
 
     switch (client_data.current_state) {
 
@@ -150,9 +150,9 @@ static s16 read_measurement(const struct sgp_profile *profile) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-static s16 sgp30_run_profile(const struct sgp_profile *profile) {
-    u32 duration_us = profile->duration_us + 5;
-    s16 ret;
+static int16_t sgp30_run_profile(const struct sgp_profile *profile) {
+    uint32_t duration_us = profile->duration_us + 5;
+    int16_t ret;
 
     ret = sensirion_i2c_write_cmd(SGP_I2C_ADDRESS, profile->command);
     if (ret != STATUS_OK)
@@ -174,8 +174,8 @@ static s16 sgp30_run_profile(const struct sgp_profile *profile) {
  *
  * Return:      A pointer to the profile or NULL if the profile does not exists
  */
-static const struct sgp_profile *sgp30_get_profile_by_number(u16 number) {
-    u8 i;
+static const struct sgp_profile *sgp30_get_profile_by_number(uint16_t number) {
+    uint8_t i;
     const struct sgp_profile *profile = NULL;
 
     for (i = 0; i < client_data.otp_features->number_of_profiles; i++) {
@@ -197,7 +197,7 @@ static const struct sgp_profile *sgp30_get_profile_by_number(u16 number) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-static s16 sgp30_run_profile_by_number(u16 number) {
+static int16_t sgp30_run_profile_by_number(uint16_t number) {
     const struct sgp_profile *profile;
 
     profile = sgp30_get_profile_by_number(number);
@@ -215,9 +215,9 @@ static s16 sgp30_run_profile_by_number(u16 number) {
  *
  * Return:    STATUS_OK on success, STATUS_FAIL otherwise
  */
-static s16 sgp30_detect_featureset_version(u16 *featureset) {
-    s16 i, j;
-    u16 feature_set_version = *featureset;
+static int16_t sgp30_detect_featureset_version(uint16_t *featureset) {
+    int16_t i, j;
+    uint16_t feature_set_version = *featureset;
     const struct sgp_otp_featureset *sgp30_featureset;
 
     client_data.info.feature_set_version = feature_set_version;
@@ -251,9 +251,9 @@ static s16 sgp30_detect_featureset_version(u16 *featureset) {
  *
  * Return: STATUS_OK on a successful self-test, an error code otherwise
  */
-s16 sgp30_measure_test(u16 *test_result) {
-    u16 measure_test_word_buf[SGP_CMD_MEASURE_TEST_WORDS];
-    s16 ret;
+int16_t sgp30_measure_test(uint16_t *test_result) {
+    uint16_t measure_test_word_buf[SGP_CMD_MEASURE_TEST_WORDS];
+    int16_t ret;
 
     *test_result = 0;
 
@@ -278,9 +278,9 @@ s16 sgp30_measure_test(u16 *test_result) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_iaq() {
+int16_t sgp30_measure_iaq() {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgp30_get_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (profile == NULL)
@@ -306,9 +306,9 @@ s16 sgp30_measure_iaq() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_read_iaq(u16 *tvoc_ppb, u16 *co2_eq_ppm) {
+int16_t sgp30_read_iaq(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgp30_get_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (profile == NULL)
@@ -334,8 +334,9 @@ s16 sgp30_read_iaq(u16 *tvoc_ppb, u16 *co2_eq_ppm) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm) {
-    s16 ret;
+int16_t sgp30_measure_iaq_blocking_read(uint16_t *tvoc_ppb,
+                                        uint16_t *co2_eq_ppm) {
+    int16_t ret;
 
     ret = sgp30_run_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (ret != STATUS_OK)
@@ -355,7 +356,7 @@ s16 sgp30_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_tvoc() {
+int16_t sgp30_measure_tvoc() {
     return sgp30_measure_iaq();
 }
 
@@ -369,8 +370,8 @@ s16 sgp30_measure_tvoc() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_read_tvoc(u16 *tvoc_ppb) {
-    u16 co2_eq_ppm;
+int16_t sgp30_read_tvoc(uint16_t *tvoc_ppb) {
+    uint16_t co2_eq_ppm;
     return sgp30_read_iaq(tvoc_ppb, &co2_eq_ppm);
 }
 
@@ -381,8 +382,8 @@ s16 sgp30_read_tvoc(u16 *tvoc_ppb) {
  *
  * Return:  tVOC concentration in ppb. Negative if it fails.
  */
-s16 sgp30_measure_tvoc_blocking_read(u16 *tvoc_ppb) {
-    u16 co2_eq_ppm;
+int16_t sgp30_measure_tvoc_blocking_read(uint16_t *tvoc_ppb) {
+    uint16_t co2_eq_ppm;
     return sgp30_measure_iaq_blocking_read(tvoc_ppb, &co2_eq_ppm);
 }
 
@@ -394,7 +395,7 @@ s16 sgp30_measure_tvoc_blocking_read(u16 *tvoc_ppb) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_co2_eq() {
+int16_t sgp30_measure_co2_eq() {
     return sgp30_measure_iaq();
 }
 
@@ -408,8 +409,8 @@ s16 sgp30_measure_co2_eq() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_read_co2_eq(u16 *co2_eq_ppm) {
-    u16 tvoc_ppb;
+int16_t sgp30_read_co2_eq(uint16_t *co2_eq_ppm) {
+    uint16_t tvoc_ppb;
     return sgp30_read_iaq(&tvoc_ppb, co2_eq_ppm);
 }
 
@@ -420,8 +421,8 @@ s16 sgp30_read_co2_eq(u16 *co2_eq_ppm) {
  *
  * Return:  CO2-Equivalent concentration in ppm. Negative if it fails.
  */
-s16 sgp30_measure_co2_eq_blocking_read(u16 *co2_eq_ppm) {
-    u16 tvoc_ppb;
+int16_t sgp30_measure_co2_eq_blocking_read(uint16_t *co2_eq_ppm) {
+    uint16_t tvoc_ppb;
     return sgp30_measure_iaq_blocking_read(&tvoc_ppb, co2_eq_ppm);
 }
 
@@ -434,9 +435,9 @@ s16 sgp30_measure_co2_eq_blocking_read(u16 *co2_eq_ppm) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_raw_blocking_read(u16 *ethanol_raw_signal,
-                                    u16 *h2_raw_signal) {
-    s16 ret;
+int16_t sgp30_measure_raw_blocking_read(uint16_t *ethanol_raw_signal,
+                                        uint16_t *h2_raw_signal) {
+    int16_t ret;
 
     ret = sgp30_run_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (ret != STATUS_OK)
@@ -456,9 +457,9 @@ s16 sgp30_measure_raw_blocking_read(u16 *ethanol_raw_signal,
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_measure_raw() {
+int16_t sgp30_measure_raw() {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgp30_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (profile == NULL)
@@ -483,9 +484,9 @@ s16 sgp30_measure_raw() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_read_raw(u16 *ethanol_raw_signal, u16 *h2_raw_signal) {
+int16_t sgp30_read_raw(uint16_t *ethanol_raw_signal, uint16_t *h2_raw_signal) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgp30_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (profile == NULL)
@@ -512,19 +513,19 @@ s16 sgp30_read_raw(u16 *ethanol_raw_signal, u16 *h2_raw_signal) {
  * sgp30_set_iaq_baseline() with a valid baseline. This functions returns
  * STATUS_FAIL if the baseline value is not valid.
  *
- * @baseline:   Pointer to raw u32 where to store the baseline
+ * @baseline:   Pointer to raw uint32_t where to store the baseline
  *              If the method returns STATUS_FAIL, the baseline value must be
  *              discarded and must not be passed to sgp30_set_iaq_baseline().
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 sgp30_get_iaq_baseline(u32 *baseline) {
-    s16 ret = sgp30_run_profile_by_number(PROFILE_NUMBER_IAQ_GET_BASELINE);
+int16_t sgp30_get_iaq_baseline(uint32_t *baseline) {
+    int16_t ret = sgp30_run_profile_by_number(PROFILE_NUMBER_IAQ_GET_BASELINE);
     if (ret != STATUS_OK)
         return ret;
 
-    *baseline = (((u32)client_data.buffer.words[0]) << 16) |
-                (u32)client_data.buffer.words[1];
+    *baseline = (((uint32_t)client_data.buffer.words[0]) << 16) |
+                (uint32_t)client_data.buffer.words[1];
 
     if (!SGP_VALID_IAQ_BASELINE(*baseline))
         return STATUS_FAIL;
@@ -534,7 +535,7 @@ s16 sgp30_get_iaq_baseline(u32 *baseline) {
 
 /**
  * sgp30_set_iaq_baseline() - set the on-chip baseline
- * @baseline:   A raw u32 baseline
+ * @baseline:   A raw uint32_t baseline
  *              This value must be unmodified from what was retrieved by a
  *              successful call to sgp30_get_iaq_baseline() with return value
  *              STATUS_OK. A persisted baseline should not be set if it is
@@ -542,10 +543,11 @@ s16 sgp30_get_iaq_baseline(u32 *baseline) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_set_iaq_baseline(u32 baseline) {
+int16_t sgp30_set_iaq_baseline(uint32_t baseline) {
     const struct sgp_profile *profile;
-    u16 words[SENSIRION_NUM_WORDS(baseline)] = {
-        (u16)((baseline & 0xffff0000) >> 16), (u16)(baseline & 0x0000ffff)};
+    uint16_t words[SENSIRION_NUM_WORDS(baseline)] = {
+        (uint16_t)((baseline & 0xffff0000) >> 16),
+        (uint16_t)(baseline & 0x0000ffff)};
 
     if (!SGP_VALID_IAQ_BASELINE(baseline))
         return STATUS_FAIL;
@@ -566,15 +568,15 @@ s16 sgp30_set_iaq_baseline(u32 baseline) {
  * quality even before the first clean air event.
  *
  * @tvoc_inceptive_baseline:
- *              Pointer to raw u16 where to store the inceptive baseline
+ *              Pointer to raw uint16_t where to store the inceptive baseline
  *              If the method returns STATUS_FAIL, the inceptive baseline value
  *              must be discarded and must not be passed to
  *              sgp30_set_tvoc_baseline().
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline) {
-    s16 ret;
+int16_t sgp30_get_tvoc_inceptive_baseline(uint16_t *tvoc_inceptive_baseline) {
+    int16_t ret;
 
     ret = sgp30_run_profile_by_number(
         PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE);
@@ -588,14 +590,14 @@ s16 sgp30_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline) {
 
 /**
  * sgp30_set_tvoc_baseline() - set the on-chip tVOC baseline
- * @baseline:   A raw u16 tVOC baseline
+ * @baseline:   A raw uint16_t tVOC baseline
  *              This value must be unmodified from what was retrieved by a
  *              successful call to sgp30_get_tvoc_inceptive_baseline() with
  * return value STATUS_OK.
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_set_tvoc_baseline(u16 tvoc_baseline) {
+int16_t sgp30_set_tvoc_baseline(uint16_t tvoc_baseline) {
     const struct sgp_profile *profile;
 
     if (!SGP_VALID_IAQ_BASELINE(tvoc_baseline))
@@ -621,10 +623,10 @@ s16 sgp30_set_tvoc_baseline(u16 tvoc_baseline) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_set_absolute_humidity(u32 absolute_humidity) {
-    u64 ah = absolute_humidity;
+int16_t sgp30_set_absolute_humidity(uint32_t absolute_humidity) {
+    uint64_t ah = absolute_humidity;
     const struct sgp_profile *profile;
-    u16 ah_scaled;
+    uint16_t ah_scaled;
 
     if (!SGP_REQUIRE_FS(client_data.info.feature_set_version, 1, 0))
         return STATUS_FAIL; /* feature unavailable */
@@ -637,7 +639,7 @@ s16 sgp30_set_absolute_humidity(u32 absolute_humidity) {
         return STATUS_FAIL;
 
     /* ah_scaled = (ah / 1000) * 256 */
-    ah_scaled = (u16)((ah * 256 * 16777) >> 24);
+    ah_scaled = (uint16_t)((ah * 256 * 16777) >> 24);
 
     return sensirion_i2c_write_cmd_with_args(SGP_I2C_ADDRESS, profile->command,
                                              &ah_scaled,
@@ -655,9 +657,9 @@ const char *sgp30_get_driver_version() {
 /**
  * sgp30_get_configured_address() - returns the configured I2C address
  *
- * Return:      u8 I2C address
+ * Return:      uint8_t I2C address
  */
-u8 sgp30_get_configured_address() {
+uint8_t sgp30_get_configured_address() {
     return SGP_I2C_ADDRESS;
 }
 
@@ -670,9 +672,11 @@ u8 sgp30_get_configured_address() {
  *
  * Return:  STATUS_OK on success
  */
-s16 sgp30_get_feature_set_version(u16 *feature_set_version, u8 *product_type) {
+int16_t sgp30_get_feature_set_version(uint16_t *feature_set_version,
+                                      uint8_t *product_type) {
     *feature_set_version = client_data.info.feature_set_version & 0x00FF;
-    *product_type = (u8)((client_data.info.feature_set_version & 0xF000) >> 12);
+    *product_type =
+        (uint8_t)((client_data.info.feature_set_version & 0xF000) >> 12);
     return STATUS_OK;
 }
 
@@ -683,7 +687,7 @@ s16 sgp30_get_feature_set_version(u16 *feature_set_version, u8 *product_type) {
  *
  * Return:  STATUS_OK on success
  */
-s16 sgp30_get_serial_id(u64 *serial_id) {
+int16_t sgp30_get_serial_id(uint64_t *serial_id) {
     *serial_id = client_data.info.serial_id;
     return STATUS_OK;
 }
@@ -693,7 +697,7 @@ s16 sgp30_get_serial_id(u64 *serial_id) {
  *
  * Return:  STATUS_OK on success.
  */
-s16 sgp30_iaq_init() {
+int16_t sgp30_iaq_init() {
     return sgp30_run_profile_by_number(PROFILE_NUMBER_IAQ_INIT);
 }
 
@@ -704,9 +708,9 @@ s16 sgp30_iaq_init() {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgp30_probe() {
-    s16 err;
-    u64 *serial_buf = &client_data.buffer.u64_value;
+int16_t sgp30_probe() {
+    int16_t err;
+    uint64_t *serial_buf = &client_data.buffer.u64_value;
 
     *serial_buf = 0;
     client_data.current_state = WAIT_STATE;

--- a/sgp30/sgp30.h
+++ b/sgp30/sgp30.h
@@ -39,39 +39,41 @@
 extern "C" {
 #endif
 
-s16 sgp30_probe(void);
-s16 sgp30_iaq_init(void);
+int16_t sgp30_probe(void);
+int16_t sgp30_iaq_init(void);
 
 const char *sgp30_get_driver_version(void);
-u8 sgp30_get_configured_address(void);
-s16 sgp30_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
-s16 sgp30_get_serial_id(u64 *serial_id);
+uint8_t sgp30_get_configured_address(void);
+int16_t sgp30_get_feature_set_version(uint16_t *feature_set_version,
+                                      uint8_t *product_type);
+int16_t sgp30_get_serial_id(uint64_t *serial_id);
 
-s16 sgp30_get_iaq_baseline(u32 *baseline);
-s16 sgp30_set_iaq_baseline(u32 baseline);
-s16 sgp30_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
-s16 sgp30_set_tvoc_baseline(u16 tvoc_baseline);
+int16_t sgp30_get_iaq_baseline(uint32_t *baseline);
+int16_t sgp30_set_iaq_baseline(uint32_t baseline);
+int16_t sgp30_get_tvoc_inceptive_baseline(uint16_t *tvoc_inceptive_baseline);
+int16_t sgp30_set_tvoc_baseline(uint16_t tvoc_baseline);
 
-s16 sgp30_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm);
-s16 sgp30_measure_iaq(void);
-s16 sgp30_read_iaq(u16 *tvoc_ppb, u16 *co2_eq_ppm);
+int16_t sgp30_measure_iaq_blocking_read(uint16_t *tvoc_ppb,
+                                        uint16_t *co2_eq_ppm);
+int16_t sgp30_measure_iaq(void);
+int16_t sgp30_read_iaq(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm);
 
-s16 sgp30_measure_tvoc_blocking_read(u16 *tvoc_ppb);
-s16 sgp30_measure_tvoc(void);
-s16 sgp30_read_tvoc(u16 *tvoc_ppb);
+int16_t sgp30_measure_tvoc_blocking_read(uint16_t *tvoc_ppb);
+int16_t sgp30_measure_tvoc(void);
+int16_t sgp30_read_tvoc(uint16_t *tvoc_ppb);
 
-s16 sgp30_measure_co2_eq_blocking_read(u16 *co2_eq_ppm);
-s16 sgp30_measure_co2_eq(void);
-s16 sgp30_read_co2_eq(u16 *co2_eq_ppm);
+int16_t sgp30_measure_co2_eq_blocking_read(uint16_t *co2_eq_ppm);
+int16_t sgp30_measure_co2_eq(void);
+int16_t sgp30_read_co2_eq(uint16_t *co2_eq_ppm);
 
-s16 sgp30_measure_raw_blocking_read(u16 *ethanol_raw_signal,
-                                    u16 *h2_raw_signal);
-s16 sgp30_measure_raw(void);
-s16 sgp30_read_raw(u16 *ethanol_raw_signal, u16 *h2_raw_signal);
+int16_t sgp30_measure_raw_blocking_read(uint16_t *ethanol_raw_signal,
+                                        uint16_t *h2_raw_signal);
+int16_t sgp30_measure_raw(void);
+int16_t sgp30_read_raw(uint16_t *ethanol_raw_signal, uint16_t *h2_raw_signal);
 
-s16 sgp30_measure_test(u16 *test_result);
+int16_t sgp30_measure_test(uint16_t *test_result);
 
-s16 sgp30_set_absolute_humidity(u32 absolute_humidity);
+int16_t sgp30_set_absolute_humidity(uint32_t absolute_humidity);
 
 #ifdef __cplusplus
 }

--- a/sgp30/sgp30_example_usage.c
+++ b/sgp30/sgp30_example_usage.c
@@ -42,11 +42,11 @@
  */
 
 int main(void) {
-    u16 i = 0;
-    s16 err;
-    u16 tvoc_ppb, co2_eq_ppm;
-    u32 iaq_baseline;
-    u16 ethanol_raw_signal, h2_raw_signal;
+    uint16_t i = 0;
+    int16_t err;
+    uint16_t tvoc_ppb, co2_eq_ppm;
+    uint32_t iaq_baseline;
+    uint16_t ethanol_raw_signal, h2_raw_signal;
 
     const char *driver_version = sgp30_get_driver_version();
     if (driver_version) {
@@ -64,8 +64,8 @@ int main(void) {
     }
     printf("SGP sensor probing successful\n");
 
-    u16 feature_set_version;
-    u8 product_type;
+    uint16_t feature_set_version;
+    uint8_t product_type;
     err = sgp30_get_feature_set_version(&feature_set_version, &product_type);
     if (err == STATUS_OK) {
         printf("Feature set version: %u\n", feature_set_version);
@@ -73,7 +73,7 @@ int main(void) {
     } else {
         printf("sgp30_get_feature_set_version failed!\n");
     }
-    u64 serial_id;
+    uint64_t serial_id;
     err = sgp30_get_serial_id(&serial_id);
     if (err == STATUS_OK) {
         printf("SerialID: %" PRIu64 "\n", serial_id);
@@ -111,7 +111,7 @@ int main(void) {
     while (1) {
         /*
          * IMPLEMENT: get absolute humidity to enable humidity compensation
-         * u32 ah = get_absolute_humidity(); // absolute humidity in mg/m^3
+         * uint32_t ah = get_absolute_humidity(); // absolute humidity in mg/m^3
          * sgp30_set_absolute_humidity(ah);
          */
 

--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -35,9 +35,10 @@
 #define PROFILE_NUMBER_SET_AH 12
 #define PROFILE_IAQ_SET_TVOC_BASELINE 14
 
-const u8 PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE = PROFILE_IAQ_SET_TVOC_BASELINE;
-const u8 PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
-const u8 PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY = PROFILE_NUMBER_SET_AH;
+const uint8_t PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE =
+    PROFILE_IAQ_SET_TVOC_BASELINE;
+const uint8_t PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
+const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY = PROFILE_NUMBER_SET_AH;
 
 static const struct sgp_signal ETHANOL_SIGNAL_FS9 = {
     .conversion_function = NULL,
@@ -177,28 +178,31 @@ static const struct sgp_profile *sgp_profiles33[] = {
     &SGP_PROFILE_SET_ABSOLUTE_HUMIDITY,
 };
 
-static const u16 supported_featureset_versions_fs9[] = {9};
-static const u16 supported_featureset_versions_fs32[] = {0x20};
-static const u16 supported_featureset_versions_fs33[] = {0x21};
+static const uint16_t supported_featureset_versions_fs9[] = {9};
+static const uint16_t supported_featureset_versions_fs32[] = {0x20};
+static const uint16_t supported_featureset_versions_fs33[] = {0x21};
 
 static const struct sgp_otp_featureset sgp_featureset9 = {
     .profiles = sgp_profiles9,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles9),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs9,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs9,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs9)};
 
 static const struct sgp_otp_featureset sgp_featureset32 = {
     .profiles = sgp_profiles32,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles32),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs32,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs32,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs32)};
 
 static const struct sgp_otp_featureset sgp_featureset33 = {
     .profiles = sgp_profiles33,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles33),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs33,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs33,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs33)};
 

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -43,26 +43,26 @@
 #define SGP_VALID_TVOC_BASELINE(b) ((b) != 0)
 
 #ifdef SGP_ADDRESS
-static const u8 SGP_I2C_ADDRESS = SGP_ADDRESS;
+static const uint8_t SGP_I2C_ADDRESS = SGP_ADDRESS;
 #else
-static const u8 SGP_I2C_ADDRESS = 0x58;
+static const uint8_t SGP_I2C_ADDRESS = 0x58;
 #endif
 
 /* command and constants for reading the serial ID */
 #define SGP_CMD_GET_SERIAL_ID_DURATION_US 500
 #define SGP_CMD_GET_SERIAL_ID_WORDS 3
-static const u16 sgpc3_cmd_get_serial_id = 0x3682;
+static const uint16_t sgpc3_cmd_get_serial_id = 0x3682;
 
 /* command and constants for reading the featureset version */
 #define SGP_CMD_GET_FEATURESET_DURATION_US 1000
 #define SGP_CMD_GET_FEATURESET_WORDS 1
-static const u16 sgpc3_cmd_get_featureset = 0x202f;
+static const uint16_t sgpc3_cmd_get_featureset = 0x202f;
 
 /* command and constants for on-chip self-test */
 #define SGP_CMD_MEASURE_TEST_DURATION_US 220000
 #define SGP_CMD_MEASURE_TEST_WORDS 1
 #define SGP_CMD_MEASURE_TEST_OK 0xd400
-static const u16 sgpc3_cmd_measure_test = 0x2032;
+static const uint16_t sgpc3_cmd_measure_test = 0x2032;
 
 static const struct sgp_otp_featureset sgpc3_features_unknown = {
     .profiles = NULL,
@@ -72,8 +72,8 @@ static const struct sgp_otp_featureset sgpc3_features_unknown = {
 enum sgpc3_state_code { WAIT_STATE, MEASURING_PROFILE_STATE };
 
 struct sgpc3_info {
-    u64 serial_id;
-    u16 feature_set_version;
+    uint64_t serial_id;
+    uint16_t feature_set_version;
 };
 
 static struct sgpc3_data {
@@ -81,8 +81,8 @@ static struct sgpc3_data {
     struct sgpc3_info info;
     const struct sgp_otp_featureset *otp_features;
     union {
-        u16 words[SGP_BUFFER_WORDS];
-        u64 u64_value;
+        uint16_t words[SGP_BUFFER_WORDS];
+        uint64_t u64_value;
     } buffer;
 } client_data;
 
@@ -92,11 +92,11 @@ static struct sgpc3_data {
  * @profile:    The profile
  */
 static void unpack_signals(const struct sgp_profile *profile) {
-    s16 i, j;
+    int16_t i, j;
     const struct sgp_signal *signal;
-    u16 data_words = profile->number_of_signals;
-    u16 word_buf[data_words];
-    u16 value;
+    uint16_t data_words = profile->number_of_signals;
+    uint16_t word_buf[data_words];
+    uint16_t value;
 
     /* copy buffer */
     for (i = 0; i < data_words; i++)
@@ -119,8 +119,8 @@ static void unpack_signals(const struct sgp_profile *profile) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-static s16 read_measurement(const struct sgp_profile *profile) {
-    s16 ret;
+static int16_t read_measurement(const struct sgp_profile *profile) {
+    int16_t ret;
 
     switch (client_data.current_state) {
 
@@ -150,9 +150,9 @@ static s16 read_measurement(const struct sgp_profile *profile) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-static s16 sgpc3_run_profile(const struct sgp_profile *profile) {
-    u32 duration_us = profile->duration_us + 5;
-    s16 ret;
+static int16_t sgpc3_run_profile(const struct sgp_profile *profile) {
+    uint32_t duration_us = profile->duration_us + 5;
+    int16_t ret;
 
     ret = sensirion_i2c_write_cmd(SGP_I2C_ADDRESS, profile->command);
     if (ret != STATUS_OK)
@@ -174,8 +174,8 @@ static s16 sgpc3_run_profile(const struct sgp_profile *profile) {
  *
  * Return:      A pointer to the profile or NULL if the profile does not exists
  */
-static const struct sgp_profile *sgpc3_get_profile_by_number(u16 number) {
-    u8 i;
+static const struct sgp_profile *sgpc3_get_profile_by_number(uint16_t number) {
+    uint8_t i;
     const struct sgp_profile *profile = NULL;
 
     for (i = 0; i < client_data.otp_features->number_of_profiles; i++) {
@@ -197,7 +197,7 @@ static const struct sgp_profile *sgpc3_get_profile_by_number(u16 number) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-static s16 sgpc3_run_profile_by_number(u16 number) {
+static int16_t sgpc3_run_profile_by_number(uint16_t number) {
     const struct sgp_profile *profile;
 
     profile = sgpc3_get_profile_by_number(number);
@@ -215,9 +215,9 @@ static s16 sgpc3_run_profile_by_number(u16 number) {
  *
  * Return:    STATUS_OK on success, STATUS_FAIL otherwise
  */
-static s16 sgpc3_detect_featureset_version(u16 *featureset) {
-    s16 i, j;
-    u16 feature_set_version = *featureset;
+static int16_t sgpc3_detect_featureset_version(uint16_t *featureset) {
+    int16_t i, j;
+    uint16_t feature_set_version = *featureset;
     const struct sgp_otp_featureset *sgpc3_featureset;
 
     client_data.info.feature_set_version = feature_set_version;
@@ -251,9 +251,9 @@ static s16 sgpc3_detect_featureset_version(u16 *featureset) {
  *
  * Return: STATUS_OK on a successful self-test, an error code otherwise
  */
-s16 sgpc3_measure_test(u16 *test_result) {
-    u16 measure_test_word_buf[SGP_CMD_MEASURE_TEST_WORDS];
-    s16 ret;
+int16_t sgpc3_measure_test(uint16_t *test_result) {
+    uint16_t measure_test_word_buf[SGP_CMD_MEASURE_TEST_WORDS];
+    int16_t ret;
 
     *test_result = 0;
 
@@ -279,9 +279,9 @@ s16 sgpc3_measure_test(u16 *test_result) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_tvoc() {
+int16_t sgpc3_measure_tvoc() {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (profile == NULL)
@@ -306,9 +306,9 @@ s16 sgpc3_measure_tvoc() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_read_tvoc(u16 *tvoc_ppb) {
+int16_t sgpc3_read_tvoc(uint16_t *tvoc_ppb) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (profile == NULL)
@@ -332,8 +332,8 @@ s16 sgpc3_read_tvoc(u16 *tvoc_ppb) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_tvoc_blocking_read(u16 *tvoc_ppb) {
-    s16 ret;
+int16_t sgpc3_measure_tvoc_blocking_read(uint16_t *tvoc_ppb) {
+    int16_t ret;
 
     ret = sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_MEASURE);
     if (ret != STATUS_OK)
@@ -352,8 +352,9 @@ s16 sgpc3_measure_tvoc_blocking_read(u16 *tvoc_ppb) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_raw_blocking_read(u16 *ethanol_raw_signal) {
-    s16 ret = sgpc3_run_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
+int16_t sgpc3_measure_raw_blocking_read(uint16_t *ethanol_raw_signal) {
+    int16_t ret =
+        sgpc3_run_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (ret != STATUS_OK)
         return ret;
 
@@ -370,9 +371,9 @@ s16 sgpc3_measure_raw_blocking_read(u16 *ethanol_raw_signal) {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_raw(void) {
+int16_t sgpc3_measure_raw(void) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (profile == NULL)
@@ -396,9 +397,9 @@ s16 sgpc3_measure_raw(void) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_read_raw(u16 *ethanol_raw_signal) {
+int16_t sgpc3_read_raw(uint16_t *ethanol_raw_signal) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW_SIGNALS);
     if (profile == NULL)
@@ -422,9 +423,9 @@ s16 sgpc3_read_raw(u16 *ethanol_raw_signal) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_tvoc_and_raw_blocking_read(u16 *tvoc_ppb,
-                                             u16 *ethanol_raw_signal) {
-    s16 ret;
+int16_t sgpc3_measure_tvoc_and_raw_blocking_read(uint16_t *tvoc_ppb,
+                                                 uint16_t *ethanol_raw_signal) {
+    int16_t ret;
 
     ret = sgpc3_run_profile_by_number(PROFILE_NUMBER_MEASURE_RAW);
     if (ret != STATUS_OK)
@@ -444,9 +445,9 @@ s16 sgpc3_measure_tvoc_and_raw_blocking_read(u16 *tvoc_ppb,
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_measure_tvoc_and_raw() {
+int16_t sgpc3_measure_tvoc_and_raw() {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW);
     if (profile == NULL)
@@ -471,9 +472,10 @@ s16 sgpc3_measure_tvoc_and_raw() {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_read_tvoc_and_raw(u16 *tvoc_ppb, u16 *ethanol_raw_signal) {
+int16_t sgpc3_read_tvoc_and_raw(uint16_t *tvoc_ppb,
+                                uint16_t *ethanol_raw_signal) {
     const struct sgp_profile *profile;
-    s16 ret;
+    int16_t ret;
 
     profile = sgpc3_get_profile_by_number(PROFILE_NUMBER_MEASURE_RAW);
     if (profile == NULL)
@@ -500,14 +502,14 @@ s16 sgpc3_read_tvoc_and_raw(u16 *tvoc_ppb, u16 *ethanol_raw_signal) {
  * sgpc3_set_tvoc_baseline() with a valid baseline.
  * This functions returns STATUS_FAIL if the baseline value is not valid.
  *
- * @baseline:   Pointer to raw u16 where to store the baseline
+ * @baseline:   Pointer to raw uint16_t where to store the baseline
  *              If the method returns STATUS_FAIL, the baseline value must be
  *              discarded and must not be passed to sgpc3_set_tvoc_baseline().
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_get_tvoc_baseline(u16 *baseline) {
-    s16 ret = sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_GET_BASELINE);
+int16_t sgpc3_get_tvoc_baseline(uint16_t *baseline) {
+    int16_t ret = sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_GET_BASELINE);
     if (ret != STATUS_OK)
         return ret;
 
@@ -521,7 +523,7 @@ s16 sgpc3_get_tvoc_baseline(u16 *baseline) {
 
 /**
  * sgpc3_set_tvoc_baseline() - set the on-chip baseline
- * @baseline:   A raw u16 baseline
+ * @baseline:   A raw uint16_t baseline
  *              This value must be unmodified from what was retrieved by a
  *              successful call to sgpc3_get_tvoc_baseline() with return value
  *              STATUS_OK. A persisted baseline should not be set if it is
@@ -529,7 +531,7 @@ s16 sgpc3_get_tvoc_baseline(u16 *baseline) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_set_tvoc_baseline(u16 baseline) {
+int16_t sgpc3_set_tvoc_baseline(uint16_t baseline) {
     const struct sgp_profile *profile;
 
     if (!SGP_VALID_TVOC_BASELINE(baseline))
@@ -554,15 +556,15 @@ s16 sgpc3_set_tvoc_baseline(u16 baseline) {
  * power-mode.
  *
  * @tvoc_inceptive_baseline:
- *              Pointer to raw u16 where to store the inceptive baseline
+ *              Pointer to raw uint16_t where to store the inceptive baseline
  *              If the method returns STATUS_FAIL, the inceptive baseline value
  *              must be discarded and must not be passed to
  *              sgpc3_set_tvoc_baseline().
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline) {
-    s16 ret;
+int16_t sgpc3_get_tvoc_inceptive_baseline(uint16_t *tvoc_inceptive_baseline) {
+    int16_t ret;
 
     ret = sgpc3_run_profile_by_number(
         PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE);
@@ -585,10 +587,10 @@ s16 sgpc3_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_set_absolute_humidity(u32 absolute_humidity) {
-    u64 ah = absolute_humidity;
+int16_t sgpc3_set_absolute_humidity(uint32_t absolute_humidity) {
+    uint64_t ah = absolute_humidity;
     const struct sgp_profile *profile;
-    u16 ah_scaled;
+    uint16_t ah_scaled;
 
     if (!SGP_REQUIRE_FS(client_data.info.feature_set_version, 0, 6))
         return STATUS_FAIL; /* feature unavailable */
@@ -601,7 +603,7 @@ s16 sgpc3_set_absolute_humidity(u32 absolute_humidity) {
         return STATUS_FAIL;
 
     /* ah_scaled = (ah / 1000) * 256 */
-    ah_scaled = (u16)((ah * 256 * 16777) >> 24);
+    ah_scaled = (uint16_t)((ah * 256 * 16777) >> 24);
 
     return sensirion_i2c_write_cmd_with_args(SGP_I2C_ADDRESS, profile->command,
                                              &ah_scaled,
@@ -624,7 +626,7 @@ s16 sgpc3_set_absolute_humidity(u32 absolute_humidity) {
  *
  * Return:      STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_set_power_mode(u16 power_mode) {
+int16_t sgpc3_set_power_mode(uint16_t power_mode) {
     const struct sgp_profile *profile;
 
     if (!SGP_REQUIRE_FS(client_data.info.feature_set_version, 0, 6))
@@ -650,9 +652,9 @@ const char *sgpc3_get_driver_version() {
 /**
  * sgpc3_get_configured_address() - returns the configured I2C address
  *
- * Return:      u8 I2C address
+ * Return:      uint8_t I2C address
  */
-u8 sgpc3_get_configured_address() {
+uint8_t sgpc3_get_configured_address() {
     return SGP_I2C_ADDRESS;
 }
 
@@ -665,9 +667,11 @@ u8 sgpc3_get_configured_address() {
  *
  * Return:  STATUS_OK on success
  */
-s16 sgpc3_get_feature_set_version(u16 *feature_set_version, u8 *product_type) {
+int16_t sgpc3_get_feature_set_version(uint16_t *feature_set_version,
+                                      uint8_t *product_type) {
     *feature_set_version = client_data.info.feature_set_version & 0x00FF;
-    *product_type = (u8)((client_data.info.feature_set_version & 0xF000) >> 12);
+    *product_type =
+        (uint8_t)((client_data.info.feature_set_version & 0xF000) >> 12);
     return STATUS_OK;
 }
 
@@ -678,7 +682,7 @@ s16 sgpc3_get_feature_set_version(u16 *feature_set_version, u8 *product_type) {
  *
  * Return:  STATUS_OK on success
  */
-s16 sgpc3_get_serial_id(u64 *serial_id) {
+int16_t sgpc3_get_serial_id(uint64_t *serial_id) {
     *serial_id = client_data.info.serial_id;
     return STATUS_OK;
 }
@@ -690,7 +694,7 @@ s16 sgpc3_get_serial_id(u64 *serial_id) {
  *
  * Return:  STATUS_OK on success.
  */
-s16 sgpc3_tvoc_init_preheat() {
+int16_t sgpc3_tvoc_init_preheat() {
     return sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_INIT_CONTINUOUS);
 }
 
@@ -700,7 +704,7 @@ s16 sgpc3_tvoc_init_preheat() {
  *
  * Return:  STATUS_OK on success.
  */
-s16 sgpc3_tvoc_init_no_preheat() {
+int16_t sgpc3_tvoc_init_no_preheat() {
     return sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_INIT0);
 }
 
@@ -714,7 +718,7 @@ s16 sgpc3_tvoc_init_no_preheat() {
  *
  * Return:  STATUS_OK on success.
  */
-s16 sgpc3_tvoc_init_64s_fs5() {
+int16_t sgpc3_tvoc_init_64s_fs5() {
     return sgpc3_run_profile_by_number(PROFILE_NUMBER_IAQ_INIT64);
 }
 
@@ -726,9 +730,9 @@ s16 sgpc3_tvoc_init_64s_fs5() {
  *
  * Return:  STATUS_OK on success, an error code otherwise
  */
-s16 sgpc3_probe() {
-    s16 err;
-    u64 *serial_buf = &client_data.buffer.u64_value;
+int16_t sgpc3_probe() {
+    int16_t err;
+    uint64_t *serial_buf = &client_data.buffer.u64_value;
 
     *serial_buf = 0;
     client_data.current_state = WAIT_STATE;

--- a/sgpc3/sgpc3.h
+++ b/sgpc3/sgpc3.h
@@ -39,36 +39,38 @@
 extern "C" {
 #endif
 
-s16 sgpc3_probe(void);
-s16 sgpc3_tvoc_init_preheat(void);
-s16 sgpc3_tvoc_init_no_preheat(void);
-s16 sgpc3_tvoc_init_64s_fs5(void);
+int16_t sgpc3_probe(void);
+int16_t sgpc3_tvoc_init_preheat(void);
+int16_t sgpc3_tvoc_init_no_preheat(void);
+int16_t sgpc3_tvoc_init_64s_fs5(void);
 
 const char *sgpc3_get_driver_version(void);
-u8 sgpc3_get_configured_address(void);
-s16 sgpc3_get_feature_set_version(u16 *feature_set_version, u8 *product_type);
-s16 sgpc3_get_serial_id(u64 *serial_id);
+uint8_t sgpc3_get_configured_address(void);
+int16_t sgpc3_get_feature_set_version(uint16_t *feature_set_version,
+                                      uint8_t *product_type);
+int16_t sgpc3_get_serial_id(uint64_t *serial_id);
 
-s16 sgpc3_get_tvoc_baseline(u16 *baseline);
-s16 sgpc3_set_tvoc_baseline(u16 baseline);
-s16 sgpc3_get_tvoc_inceptive_baseline(u16 *tvoc_inceptive_baseline);
+int16_t sgpc3_get_tvoc_baseline(uint16_t *baseline);
+int16_t sgpc3_set_tvoc_baseline(uint16_t baseline);
+int16_t sgpc3_get_tvoc_inceptive_baseline(uint16_t *tvoc_inceptive_baseline);
 
-s16 sgpc3_measure_tvoc_blocking_read(u16 *tvoc_ppb);
-s16 sgpc3_measure_tvoc(void);
-s16 sgpc3_read_tvoc(u16 *tvoc_ppb);
+int16_t sgpc3_measure_tvoc_blocking_read(uint16_t *tvoc_ppb);
+int16_t sgpc3_measure_tvoc(void);
+int16_t sgpc3_read_tvoc(uint16_t *tvoc_ppb);
 
-s16 sgpc3_measure_raw_blocking_read(u16 *ethanol_raw_signal);
-s16 sgpc3_measure_raw(void);
-s16 sgpc3_read_raw(u16 *ethanol_raw_signal);
+int16_t sgpc3_measure_raw_blocking_read(uint16_t *ethanol_raw_signal);
+int16_t sgpc3_measure_raw(void);
+int16_t sgpc3_read_raw(uint16_t *ethanol_raw_signal);
 
-s16 sgpc3_measure_tvoc_and_raw_blocking_read(u16 *tvoc_ppb,
-                                             u16 *ethanol_raw_signal);
-s16 sgpc3_measure_tvoc_and_raw(void);
-s16 sgpc3_read_tvoc_and_raw(u16 *tvoc_ppb, u16 *ethanol_raw_signal);
+int16_t sgpc3_measure_tvoc_and_raw_blocking_read(uint16_t *tvoc_ppb,
+                                                 uint16_t *ethanol_raw_signal);
+int16_t sgpc3_measure_tvoc_and_raw(void);
+int16_t sgpc3_read_tvoc_and_raw(uint16_t *tvoc_ppb,
+                                uint16_t *ethanol_raw_signal);
 
-s16 sgpc3_set_power_mode(u16 power_mode);
-s16 sgpc3_set_absolute_humidity(u32 absolute_humidity);
-s16 sgpc3_measure_test(u16 *test_result);
+int16_t sgpc3_set_power_mode(uint16_t power_mode);
+int16_t sgpc3_set_absolute_humidity(uint32_t absolute_humidity);
+int16_t sgpc3_measure_test(uint16_t *test_result);
 
 #ifdef __cplusplus
 }

--- a/sgpc3/sgpc3_example_usage.c
+++ b/sgpc3/sgpc3_example_usage.c
@@ -42,11 +42,11 @@
  */
 
 int main(void) {
-    u16 i = 0;
-    s16 err;
-    u16 tvoc_ppb;
-    u16 tvoc_baseline;
-    u16 ethanol_raw_signal;
+    uint16_t i = 0;
+    int16_t err;
+    uint16_t tvoc_ppb;
+    uint16_t tvoc_baseline;
+    uint16_t ethanol_raw_signal;
 
     const char *driver_version = sgpc3_get_driver_version();
     if (driver_version) {
@@ -64,8 +64,8 @@ int main(void) {
     }
     printf("SGP sensor probing successful\n");
 
-    u16 feature_set_version;
-    u8 product_type;
+    uint16_t feature_set_version;
+    uint8_t product_type;
     err = sgpc3_get_feature_set_version(&feature_set_version, &product_type);
     if (err == STATUS_OK) {
         printf("Feature set version: %u\n", feature_set_version);
@@ -73,7 +73,7 @@ int main(void) {
     } else {
         printf("sgpc3_get_feature_set_version failed!\n");
     }
-    u64 serial_id;
+    uint64_t serial_id;
     err = sgpc3_get_serial_id(&serial_id);
     if (err == STATUS_OK) {
         printf("SerialID: %" PRIu64 "\n", serial_id);

--- a/sgpc3/sgpc3_featureset.c
+++ b/sgpc3/sgpc3_featureset.c
@@ -41,16 +41,18 @@
 #define PROFILE_IAQ_INIT184 13
 #define PROFILE_IAQ_INIT_CONTINUOUS 21
 
-const u8 PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
-const u8 PROFILE_NUMBER_MEASURE_RAW = PROFILE_IAQ_MEASURE_RAW;
-const u8 PROFILE_NUMBER_IAQ_INIT0 = PROFILE_IAQ_INIT0;
-const u8 PROFILE_NUMBER_IAQ_INIT16 = PROFILE_IAQ_INIT16;
-const u8 PROFILE_NUMBER_IAQ_INIT64 = PROFILE_IAQ_INIT64;
-const u8 PROFILE_NUMBER_IAQ_INIT184 = PROFILE_IAQ_INIT184;
-const u8 PROFILE_NUMBER_IAQ_INIT_CONTINUOUS = PROFILE_IAQ_INIT_CONTINUOUS;
-const u8 PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE = PROFILE_NUMBER_IAQ_SET_BASELINE;
-const u8 PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY = PROFILE_SET_ABSOLUTE_HUMIDITY;
-const u8 PROFILE_NUMBER_SET_POWER_MODE = PROFILE_SET_POWER_MODE;
+const uint8_t PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
+const uint8_t PROFILE_NUMBER_MEASURE_RAW = PROFILE_IAQ_MEASURE_RAW;
+const uint8_t PROFILE_NUMBER_IAQ_INIT0 = PROFILE_IAQ_INIT0;
+const uint8_t PROFILE_NUMBER_IAQ_INIT16 = PROFILE_IAQ_INIT16;
+const uint8_t PROFILE_NUMBER_IAQ_INIT64 = PROFILE_IAQ_INIT64;
+const uint8_t PROFILE_NUMBER_IAQ_INIT184 = PROFILE_IAQ_INIT184;
+const uint8_t PROFILE_NUMBER_IAQ_INIT_CONTINUOUS = PROFILE_IAQ_INIT_CONTINUOUS;
+const uint8_t PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE =
+    PROFILE_NUMBER_IAQ_SET_BASELINE;
+const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY =
+    PROFILE_SET_ABSOLUTE_HUMIDITY;
+const uint8_t PROFILE_NUMBER_SET_POWER_MODE = PROFILE_SET_POWER_MODE;
 
 static const struct sgp_signal ETHANOL_SIGNAL = {
     .conversion_function = NULL,
@@ -232,28 +234,31 @@ static const struct sgp_profile *sgp_profiles_fs6[] = {
     &SGP_PROFILE_SET_POWER_MODE,
 };
 
-static const u16 supported_featureset_versions_fs4[] = {0x1004};
-static const u16 supported_featureset_versions_fs5[] = {0x1005};
-static const u16 supported_featureset_versions_fs6[] = {0x1006};
+static const uint16_t supported_featureset_versions_fs4[] = {0x1004};
+static const uint16_t supported_featureset_versions_fs5[] = {0x1005};
+static const uint16_t supported_featureset_versions_fs6[] = {0x1006};
 
 const struct sgp_otp_featureset sgp_featureset4 = {
     .profiles = sgp_profiles_fs4,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles_fs4),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs4,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs4,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs4)};
 
 const struct sgp_otp_featureset sgp_featureset5 = {
     .profiles = sgp_profiles_fs5,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles_fs5),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs5,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs5,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs5)};
 
 const struct sgp_otp_featureset sgp_featureset6 = {
     .profiles = sgp_profiles_fs6,
     .number_of_profiles = ARRAY_SIZE(sgp_profiles_fs6),
-    .supported_featureset_versions = (u16 *)supported_featureset_versions_fs6,
+    .supported_featureset_versions =
+        (uint16_t *)supported_featureset_versions_fs6,
     .number_of_supported_featureset_versions =
         ARRAY_SIZE(supported_featureset_versions_fs6)};
 

--- a/svm30/svm30.c
+++ b/svm30/svm30.c
@@ -37,11 +37,11 @@
 
 #define T_LO (-20000)
 #define T_HI 70000
-static const u32 AH_LUT_100RH[] = {1078,  2364,  4849,  9383,   17243,
-                                   30264, 50983, 82785, 130048, 198277};
-static const u32 T_STEP = (T_HI - T_LO) / (ARRAY_SIZE(AH_LUT_100RH) - 1);
+static const uint32_t AH_LUT_100RH[] = {1078,  2364,  4849,  9383,   17243,
+                                        30264, 50983, 82785, 130048, 198277};
+static const uint32_t T_STEP = (T_HI - T_LO) / (ARRAY_SIZE(AH_LUT_100RH) - 1);
 
-static void svm_compensate_rht(s32 *temperature, s32 *humidity) {
+static void svm_compensate_rht(int32_t *temperature, int32_t *humidity) {
     *temperature = ((*temperature * 8225) >> 13) - 500;
     *humidity = (*humidity * 8397) >> 13;
 }
@@ -50,14 +50,14 @@ static void svm_compensate_rht(s32 *temperature, s32 *humidity) {
  * Convert relative humidity [%RH*1000] and temperature [mC] to
  * absolute humidity [mg/m^3]
  */
-static u32 sensirion_calc_absolute_humidity(const s32 *temperature,
-                                            const s32 *humidity) {
-    u32 t, i, rem, norm_humi, ret;
+static uint32_t sensirion_calc_absolute_humidity(const int32_t *temperature,
+                                                 const int32_t *humidity) {
+    uint32_t t, i, rem, norm_humi, ret;
 
     if (*humidity == 0)
         return 0;
 
-    norm_humi = ((u32)*humidity * 82) >> 13;
+    norm_humi = ((uint32_t)*humidity * 82) >> 13;
     t = *temperature - T_LO;
     i = t / T_STEP;
     rem = t % T_STEP;
@@ -93,12 +93,12 @@ const char *svm_get_driver_version() {
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 svm_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm,
-                                  s32 *temperature, s32 *humidity) {
-    u32 absolute_humidity;
-    u16 sgp_feature_set;
-    u8 sgp_product_type;
-    s16 err;
+int16_t svm_measure_iaq_blocking_read(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm,
+                                      int32_t *temperature, int32_t *humidity) {
+    uint32_t absolute_humidity;
+    uint16_t sgp_feature_set;
+    uint8_t sgp_product_type;
+    int16_t err;
 
     err = sht_measure_blocking_read(temperature, humidity);
     if (err != STATUS_OK)
@@ -133,12 +133,13 @@ s16 svm_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm,
  *
  * Return:      STATUS_OK on success, else STATUS_FAIL
  */
-s16 svm_measure_raw_blocking_read(u16 *ethanol_raw_signal, u16 *h2_raw_signal,
-                                  s32 *temperature, s32 *humidity) {
-    u32 absolute_humidity;
-    u16 sgp_feature_set;
-    u8 sgp_product_type;
-    s16 err;
+int16_t svm_measure_raw_blocking_read(uint16_t *ethanol_raw_signal,
+                                      uint16_t *h2_raw_signal,
+                                      int32_t *temperature, int32_t *humidity) {
+    uint32_t absolute_humidity;
+    uint16_t sgp_feature_set;
+    uint8_t sgp_product_type;
+    int16_t err;
 
     err = sht_measure_blocking_read(temperature, humidity);
     if (err != STATUS_OK)
@@ -165,8 +166,8 @@ s16 svm_measure_raw_blocking_read(u16 *ethanol_raw_signal, u16 *h2_raw_signal,
  *
  * Return:  STATUS_OK on success.
  */
-s16 svm_probe() {
-    s16 err;
+int16_t svm_probe() {
+    int16_t err;
 
     err = sht_probe();
     if (err != STATUS_OK)

--- a/svm30/svm30.h
+++ b/svm30/svm30.h
@@ -42,13 +42,14 @@ extern "C" {
 
 const char *svm_get_driver_version();
 
-s16 svm_probe(void);
+int16_t svm_probe(void);
 
-s16 svm_measure_iaq_blocking_read(u16 *tvoc_ppb, u16 *co2_eq_ppm,
-                                  s32 *temperature, s32 *humidity);
+int16_t svm_measure_iaq_blocking_read(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm,
+                                      int32_t *temperature, int32_t *humidity);
 
-s16 svm_measure_raw_blocking_read(u16 *ethanol_raw_signal, u16 *h2_raw_signal,
-                                  s32 *temperature, s32 *humidity);
+int16_t svm_measure_raw_blocking_read(uint16_t *ethanol_raw_signal,
+                                      uint16_t *h2_raw_signal,
+                                      int32_t *temperature, int32_t *humidity);
 
 #ifdef __cplusplus
 }

--- a/svm30/svm30_example_usage.c
+++ b/svm30/svm30_example_usage.c
@@ -39,11 +39,11 @@
  */
 
 int main(void) {
-    u16 i = 0;
-    s16 err;
-    u16 tvoc_ppb, co2_eq_ppm;
-    u32 iaq_baseline;
-    s32 temperature, humidity;
+    uint16_t i = 0;
+    int16_t err;
+    uint16_t tvoc_ppb, co2_eq_ppm;
+    uint32_t iaq_baseline;
+    int32_t temperature, humidity;
 
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */


### PR DESCRIPTION
This patch includes the changes from the following commands:

    find . -type f \
        \( -name '*\.[ch]' -o -name '*\.cpp' -o -name '*\.ino' \) -print0 \
        | xargs -0 sed -i \
        -e 's/\bu\([0-9]\{1,2\}\)\b/uint\1_t/g' \
        -e 's/\bs\([0-9]\{1,2\}\)\b/int\1_t/g' \
        -e 's/\bf32\b/float32_t/g'
    make style-fix

This commit updates embedded-common