### PR TITLE
Faster FS1.0 timing

### DIFF
--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -146,6 +146,15 @@ static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS9 = {
     .name = "measure_signals",
 };
 
+static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS32 = {
+    .number = PROFILE_NUMBER_RAW_SIGNALS,
+    .duration_us = 25000, /* more agressive timing since FS1.0 (32) */
+    .signals = SGP_PROFILE_MEASURE_SIGNALS_SIGNALS9, /* same signals as FS0.9 */
+    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_SIGNALS_SIGNALS9),
+    .command = 0x2050,
+    .name = "measure_signals",
+};
+
 static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
     .number = PROFILE_NUMBER_SET_AH,
     .duration_us = 10000,
@@ -164,7 +173,7 @@ static const struct sgp_profile *sgp_profiles9[] = {
 static const struct sgp_profile *sgp_profiles32[] = {
     &SGP_PROFILE_IAQ_INIT,         &SGP_PROFILE_IAQ_MEASURE9,
     &SGP_PROFILE_IAQ_GET_BASELINE, &SGP_PROFILE_IAQ_SET_BASELINE,
-    &SGP_PROFILE_MEASURE_SIGNALS9, &SGP_PROFILE_SET_ABSOLUTE_HUMIDITY,
+    &SGP_PROFILE_MEASURE_SIGNALS32, &SGP_PROFILE_SET_ABSOLUTE_HUMIDITY,
 };
 
 static const struct sgp_profile *sgp_profiles33[] = {
@@ -174,7 +183,7 @@ static const struct sgp_profile *sgp_profiles33[] = {
     &SGP_PROFILE_IAQ_SET_BASELINE,
     &SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
     &SGP_PROFILE_IAQ_SET_TVOC_BASELINE,
-    &SGP_PROFILE_MEASURE_SIGNALS9,
+    &SGP_PROFILE_MEASURE_SIGNALS32,
     &SGP_PROFILE_SET_ABSOLUTE_HUMIDITY,
 };
 

--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -187,7 +187,13 @@ static const struct sgp_profile *sgp_profiles33[] = {
     &SGP_PROFILE_SET_ABSOLUTE_HUMIDITY,
 };
 
+/* Only the oldest supported release must be listed explicitly for each feature
+ * set group, since minor versions are forward compatible when the major version
+ * matches.
+ * E.g. FS1.2 (34) is guaranteed to work with the driver for FS1.1 (33) */
+/* Feature sets 0.x */
 static const uint16_t supported_featureset_versions_fs9[] = {9};
+/* Feature sets 1.x */
 static const uint16_t supported_featureset_versions_fs32[] = {0x20};
 static const uint16_t supported_featureset_versions_fs33[] = {0x21};
 


### PR DESCRIPTION
* Faster sgp30_measure_raw_blocking_read when using Featureset 1.0+ (now 25 instead of 200ms)
* Updated documentation to make it clear that the feature set versions are forward compatible
* Update embedded-common