### PR TITLE
Avoid 64b temporary on absolute humidity conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
               instead of 200ms.
 * [`changed`] CFLAGS: Enable strict aliasing warnings by default, add `-Os` to
               SGPC3.
+* [`changed`] Avoid the use of a 64b temporary when converting absolute humidity
 
 ## [5.0.0] - 2019-05-17
 

--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -624,7 +624,6 @@ int16_t sgp30_set_tvoc_baseline(uint16_t tvoc_baseline) {
  * Return:      STATUS_OK on success, an error code otherwise
  */
 int16_t sgp30_set_absolute_humidity(uint32_t absolute_humidity) {
-    uint64_t ah = absolute_humidity;
     const struct sgp_profile *profile;
     uint16_t ah_scaled;
 
@@ -638,8 +637,8 @@ int16_t sgp30_set_absolute_humidity(uint32_t absolute_humidity) {
     if (absolute_humidity > 256000)
         return STATUS_FAIL;
 
-    /* ah_scaled = (ah / 1000) * 256 */
-    ah_scaled = (uint16_t)((ah * 256 * 16777) >> 24);
+    /* ah_scaled = (absolute_humidity / 1000) * 256 */
+    ah_scaled = (uint16_t)((absolute_humidity * 16777) >> 16);
 
     return sensirion_i2c_write_cmd_with_args(SGP_I2C_ADDRESS, profile->command,
                                              &ah_scaled,

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -588,7 +588,6 @@ int16_t sgpc3_get_tvoc_inceptive_baseline(uint16_t *tvoc_inceptive_baseline) {
  * Return:      STATUS_OK on success, an error code otherwise
  */
 int16_t sgpc3_set_absolute_humidity(uint32_t absolute_humidity) {
-    uint64_t ah = absolute_humidity;
     const struct sgp_profile *profile;
     uint16_t ah_scaled;
 
@@ -602,8 +601,8 @@ int16_t sgpc3_set_absolute_humidity(uint32_t absolute_humidity) {
     if (absolute_humidity > 256000)
         return STATUS_FAIL;
 
-    /* ah_scaled = (ah / 1000) * 256 */
-    ah_scaled = (uint16_t)((ah * 256 * 16777) >> 24);
+    /* ah_scaled = (absolute_humidity / 1000) * 256 */
+    ah_scaled = (uint16_t)((absolute_humidity * 16777) >> 16);
 
     return sensirion_i2c_write_cmd_with_args(SGP_I2C_ADDRESS, profile->command,
                                              &ah_scaled,


### PR DESCRIPTION
Avoid the use of a 64bit temporary value when converting the absolute
humidity value from user input to chip input.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
