### PR TITLE
Makefile: simplify and compile binary in one batch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,76 @@ jobs:
           command: git submodule update --init
       - run: apt update
       - run: apt install -y zip
+      - run: make prepare
+      - run: make
+      - run: make clean
+      - run: make release
       - run:
-          name: build drivers
-          command: make && make clean
+          name: build stub release drivers
+          command: |
+              cd release/sgp30
+              make CONFIG_I2C_TYPE=hw_i2c
+              make CONFIG_I2C_TYPE=sw_i2c
+              make clean
+              cd -
+              cd release/sgpc3
+              make CONFIG_I2C_TYPE=hw_i2c
+              make CONFIG_I2C_TYPE=sw_i2c
+              make clean
+              cd -
+              cd release/svm30
+              make CONFIG_I2C_TYPE=hw_i2c
+              make CONFIG_I2C_TYPE=sw_i2c
+              make clean
+              cd -
       - run:
-          name: create and build release
-          command: make release
+          name: build Linux release drivers
+          command: |
+              cd release/sgp30
+              make CONFIG_I2C_TYPE=hw_i2c hw_i2c_impl_src=hw_i2c/sample-implementations/linux_user_space/sensirion_hw_i2c_implementation.c
+              make CONFIG_I2C_TYPE=sw_i2c sw_i2c_impl_src=sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+              make clean
+              cd -
+              cd release/sgpc3
+              make CONFIG_I2C_TYPE=hw_i2c hw_i2c_impl_src=hw_i2c/sample-implementations/linux_user_space/sensirion_hw_i2c_implementation.c
+              make CONFIG_I2C_TYPE=sw_i2c sw_i2c_impl_src=sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+              make clean
+              cd -
+              cd release/svm30
+              make CONFIG_I2C_TYPE=hw_i2c hw_i2c_impl_src=hw_i2c/sample-implementations/linux_user_space/sensirion_hw_i2c_implementation.c
+              make CONFIG_I2C_TYPE=sw_i2c sw_i2c_impl_src=sw_i2c/sample-implementations/linux_user_space/sensirion_sw_i2c_implementation.c
+              make clean
+              cd -
+
+  deploy:
+    docker:
+      - image: gcc:5.5
+    steps:
+      - checkout
+      - run:
+          name: update common repo
+          command: git submodule update --init
+      - run: apt update
+      - run: apt install -y zip
+      - run: make release
+      - run:
+          name: Move zip files to artifact directory
+          command: |
+            mkdir -p /releases
+            mv release/*.zip /releases/
+      - store-artifacts:
+          path: /releases
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 *.o
 /release
-/sgp30/sgp30_example_usage_hw_i2c
-/sgp30/sgp30_example_usage_sw_i2c
-/sgpc3/sgpc3_example_usage_hw_i2c
-/sgpc3/sgpc3_example_usage_sw_i2c
-/svm30/svm30_example_usage_hw_i2c
-/svm30/svm30_example_usage_sw_i2c
+/sgp30/sgp30_example_usage
+/sgp30/user_config.inc
+/sgpc3/sgpc3_example_usage
+/sgpc3/user_config.inc
+/svm30/svm30_example_usage
+/svm30/user_config.inc
 /sgp-common/sgp_git_version.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [`changed`] CFLAGS: Enable strict aliasing warnings by default, add `-Os` to
               SGPC3.
 * [`changed`] Avoid the use of a 64b temporary when converting absolute humidity
+* [`changed`] Split out `default_config.inc` from Makefile to configure paths
+              and CFLAGS for SGP30, SGPC3 and SVM30 drivers
+* [`changed`] Only one example with either `hw_i2c` or `sw_i2c` is built,
+              depending on `CONFIG_I2C_TYPE`. Defaults to `hw_i2c`.
 
 ## [5.0.0] - 2019-05-17
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ release_drivers=$(foreach d, $(drivers), release/$(d))
 
 .PHONY: FORCE all $(release_drivers) $(clean_drivers) style-check style-fix
 
-all: $(drivers)
+all: prepare $(drivers)
 
-$(drivers): sgp-common/sgp_git_version.c FORCE
+prepare: sgp-common/sgp_git_version.c
+
+$(drivers): prepare
 	cd $@ && $(MAKE) $(MFLAGS)
 
 sgp-common/sgp_git_version.c: FORCE
@@ -27,8 +29,11 @@ $(release_drivers): sgp-common/sgp_git_version.c
 	cp -r embedded-common/* "$${pkgdir}" && \
 	cp -r sgp-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
-	perl -pi -e 's/^sensirion_common_dir :=.*$$/sensirion_common_dir := ./' "$${pkgdir}/Makefile" && \
-	perl -pi -e 's/^sgp_common_dir :=.*$$/sgp_common_dir := ./' "$${pkgdir}/Makefile" && \
+	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo 'sgp_common_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo 'sgp30_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo 'sgpc3_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo 'svm30_dir = .' >> $${pkgdir}/user_config.inc && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \
 	cd release && zip -r "$${pkgname}.zip" "$${pkgname}" && cd - && \
 	ln -sf $${pkgname} $@
@@ -44,8 +49,9 @@ release/svm30: release/sgp30
 	cp -r ../embedded-sht/shtc1/* $${pkgdir} && \
 	cp svm30/Makefile $${pkgdir} && \
 	cp svm30/*.[ch] $${pkgdir} && \
-	for i in sht_source_dir sht_common_dir sgp_source_dir sgp_common_dir sensirion_common_dir; \
-		do perl -pi -e "s/^$$i :=.*$$/$$i := ./" "$${pkgdir}/Makefile"; \
+	cp svm30/default_config.inc $${pkgdir} && \
+	for i in sensirion_common_dir sgp_common_dir sht_common_dir sgp30_dir shtc1_dir svm30_dir; \
+		do echo "$$i = ." >> $${pkgdir}/user_config.inc; \
 	done && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \
 	cd release && zip -r "$${pkgname}.zip" "$${pkgname}" && cd - && \

--- a/sgp-common/sgp_featureset.h
+++ b/sgp-common/sgp_featureset.h
@@ -40,9 +40,6 @@ extern "C" {
 #define SGP_WORD_LEN 2
 #define SGP_COMMAND_LEN SGP_WORD_LEN
 
-/* maximal size of signal and profile names */
-#define NAME_SIZE 32
-
 #define PROFILE_NUMBER_IAQ_INIT 0
 #define PROFILE_NUMBER_IAQ_MEASURE 1
 #define PROFILE_NUMBER_IAQ_GET_BASELINE 2
@@ -79,20 +76,12 @@ extern const uint8_t PROFILE_NUMBER_SET_POWER_MODE;
       ((((chip_fs)&0x00E0) >> 5) == (major)) &&                                \
       (((chip_fs)&0x001F) >= (minor))))
 
-struct sgp_signal {
-    uint16_t (*conversion_function)(uint16_t);
-    char name[NAME_SIZE];
-};
-
 struct sgp_profile {
     /* expected duration of measurement, i.e., when to return for data */
     const uint32_t duration_us;
-    /* signals */
-    const struct sgp_signal **signals;
     const uint16_t number_of_signals;
     const uint16_t command;
     const uint8_t number;
-    const char name[NAME_SIZE];
 };
 
 struct sgp_otp_featureset {

--- a/sgp30/Makefile
+++ b/sgp30/Makefile
@@ -1,44 +1,13 @@
-sensirion_common_dir := ../embedded-common
-sgp_common_dir := ../sgp-common
-sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
-hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
+# See user_config.inc for build customization
+-include user_config.inc
+include default_config.inc
 
-CFLAGS := -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 \
-          -I. -I${sensirion_common_dir} -I${sgp_common_dir}
+.PHONY: all clean
 
-sensirion_common_objects := sensirion_common.o
-sgp30_binaries := sgp30_example_usage_hw_i2c sgp30_example_usage_sw_i2c
-sgp30_featureset := sgp30_featureset.o
-sgp_featuresets += ${sgp30_featureset}
-sgp_binaries += ${sgp30_binaries}
+all: sgp30_example_usage
 
-sw_objects := sensirion_sw_i2c.o sensirion_sw_i2c_implementation.o
-hw_objects := sensirion_hw_i2c_implementation.o
-all_objects := ${sensirion_common_objects} ${hw_objects} ${sw_objects} ${sgp_featuresets} sgp_git_version.o sgp30.o
-
-.PHONY: all
-
-all: ${sgp_binaries}
-
-sgp_git_version.o: ${sgp_common_dir}/sgp_git_version.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_common.o: ${sensirion_common_dir}/sensirion_common.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_sw_i2c_implementation.o: ${sw_i2c_dir}/sensirion_sw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_hw_i2c_implementation.o: ${hw_i2c_dir}/sensirion_hw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-
-sensirion_sw_i2c.o: ${sw_i2c_dir}/sensirion_sw_i2c.c
-	$(CC) -I${sw_i2c_dir} $(CFLAGS) -c -o $@ $^
-
-sgp30.o: ${sgp_common_dir}/sgp_featureset.h ${sensirion_common_dir}/sensirion_i2c.h sgp30.c sgp30.h
-
-sgp30_example_usage_sw_i2c: ${sensirion_common_objects} ${sw_objects} ${sgp_featuresets} sgp_git_version.o sgp30.o sgp30_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
-
-sgp30_example_usage_hw_i2c: ${sensirion_common_objects} ${hw_objects} ${sgp_featuresets} sgp_git_version.o sgp30.o sgp30_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
+sgp30_example_usage: clean
+	$(CC) $(CFLAGS) -o $@ ${sgp30_sources} ${${CONFIG_I2C_TYPE}_sources} ${sgp30_dir}/sgp30_example_usage.c
 
 clean:
-	$(RM) ${all_objects} ${sgp_binaries}
+	$(RM) sgp30_example_usage

--- a/sgp30/default_config.inc
+++ b/sgp30/default_config.inc
@@ -1,0 +1,30 @@
+sgp_driver_dir ?= ..
+sensirion_common_dir ?= ${sgp_driver_dir}/embedded-common
+sgp_common_dir ?= ${sgp_driver_dir}/sgp-common
+sgp30_dir ?= ${sgp_driver_dir}/sgp30
+CONFIG_I2C_TYPE ?= hw_i2c
+
+sw_i2c_impl_src ?= ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+hw_i2c_impl_src ?= ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+CFLAGS ?= -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC
+CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgp30_dir} \
+          -I${sensirion_common_dir}/${CONFIG_I2C_TYPE}
+
+sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
+                           ${sensirion_common_dir}/sensirion_i2c.h \
+			   ${sensirion_common_dir}/sensirion_common.h \
+			   ${sensirion_common_dir}/sensirion_common.c
+
+sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
+                     ${sgp_common_dir}/sgp_git_version.c \
+		     ${sgp_common_dir}/sgp_featureset.h
+
+sgp30_sources = ${sensirion_common_sources} ${sgp_common_sources} \
+		${sgp30_dir}/sgp30_featureset.c \
+		${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
+
+hw_i2c_sources = ${hw_i2c_impl_src}
+sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
+		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+		 ${sw_i2c_impl_src}

--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -93,25 +93,16 @@ static struct sgp30_data {
  */
 static void unpack_signals(const struct sgp_profile *profile) {
     int16_t i, j;
-    const struct sgp_signal *signal;
     uint16_t data_words = profile->number_of_signals;
     uint16_t word_buf[data_words];
-    uint16_t value;
 
     /* copy buffer */
     for (i = 0; i < data_words; i++)
         word_buf[i] = client_data.buffer.words[i];
 
     /* signals are in reverse order in the data buffer */
-    for (i = profile->number_of_signals - 1, j = 0; i >= 0; i -= 1, j += 1) {
-        signal = profile->signals[profile->number_of_signals - i - 1];
-        value = word_buf[i];
-
-        if (signal->conversion_function != NULL)
-            client_data.buffer.words[j] = signal->conversion_function(value);
-        else
-            client_data.buffer.words[j] = value;
-    }
+    for (i = profile->number_of_signals - 1, j = 0; i >= 0; i -= 1, j += 1)
+        client_data.buffer.words[j] = word_buf[i];
 }
 
 /**

--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -41,67 +41,67 @@ const uint8_t PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
 const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY = PROFILE_NUMBER_SET_AH;
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT = {
-    .number = PROFILE_NUMBER_IAQ_INIT,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2003,
+    .number = PROFILE_NUMBER_IAQ_INIT,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE_FS9 = {
-    .number = PROFILE_NUMBER_IAQ_MEASURE,
     .duration_us = 50000,
     .number_of_signals = 2,
     .command = 0x2008,
+    .number = PROFILE_NUMBER_IAQ_MEASURE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 1,
     .command = 0x20b3,
+    .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_TVOC_BASELINE = {
-    .number = PROFILE_IAQ_SET_TVOC_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2077,
+    .number = PROFILE_IAQ_SET_TVOC_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 2,
     .command = 0x2015,
+    .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x201e,
+    .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS_FS9 = {
-    .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 200000,
     .number_of_signals = 2,
     .command = 0x2050,
+    .number = PROFILE_NUMBER_RAW_SIGNALS,
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS_FS32 = {
     /* same signals as FS0.9 */
-    .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 25000, /* more agressive timing since FS1.0 (32) */
     .number_of_signals = 2,
     .command = 0x2050,
+    .number = PROFILE_NUMBER_RAW_SIGNALS,
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
-    .number = PROFILE_NUMBER_SET_AH,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2061,
+    .number = PROFILE_NUMBER_SET_AH,
 };
 
 static const struct sgp_profile *sgp_profiles_fs9[] = {

--- a/sgp30/sgp30_featureset.c
+++ b/sgp30/sgp30_featureset.c
@@ -40,129 +40,68 @@ const uint8_t PROFILE_NUMBER_IAQ_SET_TVOC_BASELINE =
 const uint8_t PROFILE_NUMBER_MEASURE_RAW_SIGNALS = PROFILE_NUMBER_RAW_SIGNALS;
 const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY = PROFILE_NUMBER_SET_AH;
 
-static const struct sgp_signal ETHANOL_SIGNAL_FS9 = {
-    .conversion_function = NULL,
-    .name = "ethanol_signal",
-};
-
-static const struct sgp_signal H2_SIGNAL_FS9 = {
-    .conversion_function = NULL,
-    .name = "h2_signal",
-};
-
-static const struct sgp_signal TVOC_PPB_FS9 = {
-    .conversion_function = NULL,
-    .name = "tVOC",
-};
-
-static const struct sgp_signal CO2_EQ_PPM = {
-    .conversion_function = NULL,
-    .name = "co2_eq",
-};
-
-static const struct sgp_signal BASELINE_WORD1 = {
-    .conversion_function = NULL,
-    .name = "baseline1",
-};
-
-static const struct sgp_signal BASELINE_WORD2 = {
-    .conversion_function = NULL,
-    .name = "baseline2",
-};
-
-static const struct sgp_signal *SGP_PROFILE_IAQ_MEASURE_SIGNALS_FS9[] = {
-    &TVOC_PPB_FS9, &CO2_EQ_PPM};
-
-static const struct sgp_signal
-    *SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE_SIGNALS[] = {&BASELINE_WORD1};
-
-static const struct sgp_signal *SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS[] = {
-    &BASELINE_WORD1, &BASELINE_WORD2};
-
-static const struct sgp_signal *SGP_PROFILE_MEASURE_SIGNALS_SIGNALS_FS9[] = {
-    &ETHANOL_SIGNAL_FS9, &H2_SIGNAL_FS9};
-
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT = {
     .number = PROFILE_NUMBER_IAQ_INIT,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2003,
-    .name = "iaq_init",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE_FS9 = {
     .number = PROFILE_NUMBER_IAQ_MEASURE,
     .duration_us = 50000,
-    .signals = SGP_PROFILE_IAQ_MEASURE_SIGNALS_FS9,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_SIGNALS_FS9),
+    .number_of_signals = 2,
     .command = 0x2008,
-    .name = "iaq_measure",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
     .duration_us = 10000,
-    .signals = SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE_SIGNALS,
-    .number_of_signals =
-        ARRAY_SIZE(SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE_SIGNALS),
+    .number_of_signals = 1,
     .command = 0x20b3,
-    .name = "iaq_get_tvoc_inceptive_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_TVOC_BASELINE = {
     .number = PROFILE_IAQ_SET_TVOC_BASELINE,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2077,
-    .name = "iaq_set_tvoc_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
     .duration_us = 10000,
-    .signals = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
+    .number_of_signals = 2,
     .command = 0x2015,
-    .name = "iaq_get_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x201e,
-    .name = "iaq_set_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS_FS9 = {
     .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 200000,
-    .signals = SGP_PROFILE_MEASURE_SIGNALS_SIGNALS_FS9,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_SIGNALS_SIGNALS_FS9),
+    .number_of_signals = 2,
     .command = 0x2050,
-    .name = "measure_signals",
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_SIGNALS_FS32 = {
+    /* same signals as FS0.9 */
     .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 25000, /* more agressive timing since FS1.0 (32) */
-    /* same signals as FS0.9 */
-    .signals = SGP_PROFILE_MEASURE_SIGNALS_SIGNALS_FS9,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_SIGNALS_SIGNALS_FS9),
+    .number_of_signals = 2,
     .command = 0x2050,
-    .name = "measure_signals",
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
     .number = PROFILE_NUMBER_SET_AH,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2061,
-    .name = "set_absolute_humidity",
 };
 
 static const struct sgp_profile *sgp_profiles_fs9[] = {

--- a/sgp30/user_config.inc
+++ b/sgp30/user_config.inc
@@ -1,0 +1,26 @@
+## This file controls the custom user build settings.
+
+## Choose either of hw_i2c or sw_i2c depending on whether you have a dedicated
+## i2c controller (hw_i2c) or are using bit-banging on GPIOs (sw_i2c)
+# CONFIG_I2C_TYPE = hw_i2c
+
+## For hw_i2c, configure the i2c HAL implementation to use.
+## Use one of the available sample-implementations or implement your own using
+## the stub.
+# hw_i2c_impl_src = ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+## For sw_i2c, configure the GPIO implementation.
+# sw_i2c_impl_src = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+
+##
+## The items below are listed as documentation but may not need customization
+##
+
+## The build paths can also be changed here if needed
+# sgp_driver_dir = ..
+# sensirion_common_dir = ${sgp_driver_dir}/embedded-common
+# sgp_common_dir = ${sgp_driver_dir}/sgp-common
+# sgp30_dir = ${sgp_driver_dir}/sgp30
+
+## If you need different CFLAGS, those can be customized as well
+# CFLAGS = -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC

--- a/sgpc3/Makefile
+++ b/sgpc3/Makefile
@@ -1,44 +1,13 @@
-sensirion_common_dir := ../embedded-common
-sgp_common_dir := ../sgp-common
-sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
-hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
+# See user_config.inc for build customization
+-include user_config.inc
+include default_config.inc
 
-CFLAGS := -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 \
-          -I. -I${sensirion_common_dir} -I${sgp_common_dir}
+.PHONY: all clean
 
-sensirion_common_objects := sensirion_common.o
-sgpc3_binaries := sgpc3_example_usage_hw_i2c sgpc3_example_usage_sw_i2c
-sgpc3_featureset := sgpc3_featureset.o
-sgp_featuresets += ${sgpc3_featureset}
-sgp_binaries += ${sgpc3_binaries}
+all: sgpc3_example_usage
 
-sw_objects := sensirion_sw_i2c.o sensirion_sw_i2c_implementation.o
-hw_objects := sensirion_hw_i2c_implementation.o
-all_objects := ${sensirion_common_objects} ${hw_objects} ${sw_objects} ${sgp_featuresets} sgp_git_version.o sgpc3.o
-
-.PHONY: all
-
-all: ${sgp_binaries}
-
-sgp_git_version.o: ${sgp_common_dir}/sgp_git_version.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_common.o: ${sensirion_common_dir}/sensirion_common.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_sw_i2c_implementation.o: ${sw_i2c_dir}/sensirion_sw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_hw_i2c_implementation.o: ${hw_i2c_dir}/sensirion_hw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-
-sensirion_sw_i2c.o: ${sw_i2c_dir}/sensirion_sw_i2c.c
-	$(CC) -I${sw_i2c_dir} $(CFLAGS) -c -o $@ $^
-
-sgpc3.o: ${sgp_common_dir}/sgp_git_version.c ${sgp_common_dir}/sgp_featureset.h ${sensirion_common_dir}/sensirion_i2c.h sgpc3.c sgpc3.h
-
-sgpc3_example_usage_sw_i2c: ${sensirion_common_objects} ${sw_objects} ${sgp_featuresets} sgp_git_version.o sgpc3.o sgpc3_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
-
-sgpc3_example_usage_hw_i2c: ${sensirion_common_objects} ${hw_objects} ${sgp_featuresets} sgp_git_version.o sgpc3.o sgpc3_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
+sgpc3_example_usage: clean
+	$(CC) $(CFLAGS) -o $@ ${sgpc3_sources} ${${CONFIG_I2C_TYPE}_sources} ${sgpc3_dir}/sgpc3_example_usage.c
 
 clean:
-	$(RM) ${all_objects} ${sgp_binaries}
+	$(RM) sgpc3_example_usage

--- a/sgpc3/default_config.inc
+++ b/sgpc3/default_config.inc
@@ -1,0 +1,30 @@
+sgp_driver_dir ?= ..
+sensirion_common_dir ?= ${sgp_driver_dir}/embedded-common
+sgp_common_dir ?= ${sgp_driver_dir}/sgp-common
+sgpc3_dir ?= ${sgp_driver_dir}/sgpc3
+CONFIG_I2C_TYPE ?= hw_i2c
+
+sw_i2c_impl_src ?= ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+hw_i2c_impl_src ?= ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+CFLAGS ?= -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC
+CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgpc3_dir} \
+          -I${sensirion_common_dir}/${CONFIG_I2C_TYPE}
+
+sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
+                           ${sensirion_common_dir}/sensirion_i2c.h \
+			   ${sensirion_common_dir}/sensirion_common.h \
+			   ${sensirion_common_dir}/sensirion_common.c
+
+sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
+                     ${sgp_common_dir}/sgp_git_version.c \
+		     ${sgp_common_dir}/sgp_featureset.h
+
+sgpc3_sources = ${sensirion_common_sources} ${sgp_common_sources} \
+		${sgpc3_dir}/sgpc3_featureset.c \
+		${sgpc3_dir}/sgpc3.h ${sgpc3_dir}/sgpc3.c
+
+hw_i2c_sources = ${hw_i2c_impl_src}
+sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
+		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+		 ${sw_i2c_impl_src}

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -93,25 +93,16 @@ static struct sgpc3_data {
  */
 static void unpack_signals(const struct sgp_profile *profile) {
     int16_t i, j;
-    const struct sgp_signal *signal;
     uint16_t data_words = profile->number_of_signals;
     uint16_t word_buf[data_words];
-    uint16_t value;
 
     /* copy buffer */
     for (i = 0; i < data_words; i++)
         word_buf[i] = client_data.buffer.words[i];
 
     /* signals are in reverse order in the data buffer */
-    for (i = profile->number_of_signals - 1, j = 0; i >= 0; i -= 1, j += 1) {
-        signal = profile->signals[profile->number_of_signals - i - 1];
-        value = word_buf[i];
-
-        if (signal->conversion_function != NULL)
-            client_data.buffer.words[j] = signal->conversion_function(value);
-        else
-            client_data.buffer.words[j] = value;
-    }
+    for (i = profile->number_of_signals - 1, j = 0; i >= 0; i -= 1, j += 1)
+        client_data.buffer.words[j] = word_buf[i];
 }
 
 /**

--- a/sgpc3/sgpc3_featureset.c
+++ b/sgpc3/sgpc3_featureset.c
@@ -54,147 +54,95 @@ const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY =
     PROFILE_SET_ABSOLUTE_HUMIDITY;
 const uint8_t PROFILE_NUMBER_SET_POWER_MODE = PROFILE_SET_POWER_MODE;
 
-static const struct sgp_signal ETHANOL_SIGNAL = {
-    .conversion_function = NULL,
-    .name = "ethanol_signal",
-};
-
-static const struct sgp_signal TVOC_PPB = {
-    .conversion_function = NULL,
-    .name = "tVOC",
-};
-
-static const struct sgp_signal BASELINE_WORD1 = {
-    .conversion_function = NULL,
-    .name = "baseline1",
-};
-
-static const struct sgp_signal *SGP_PROFILE_IAQ_MEASURE_SIGNALS[] = {&TVOC_PPB};
-
-static const struct sgp_signal *SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS[] = {
-    &BASELINE_WORD1};
-
-static const struct sgp_signal *SGP_PROFILE_MEASURE_ETOH_SIGNAL_SIGNALS[] = {
-    &ETHANOL_SIGNAL};
-
-static const struct sgp_signal *SGP_PROFILE_IAQ_MEASURE_RAW_SIGNALS[] = {
-    &TVOC_PPB, &ETHANOL_SIGNAL};
-
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT64 = {
     .number = PROFILE_IAQ_INIT64,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2003,
-    .name = "iaq_init64",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT0 = {
     .number = PROFILE_IAQ_INIT0,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2089,
-    .name = "iaq_init0",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT16 = {
     .number = PROFILE_IAQ_INIT16,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2024,
-    .name = "iaq_init16",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT184 = {
     .number = PROFILE_IAQ_INIT184,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x206a,
-    .name = "iaq_init184",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT_CONTINUOUS = {
     .number = PROFILE_IAQ_INIT_CONTINUOUS,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x20ae,
-    .name = "iaq_init_continuous",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE = {
     .number = PROFILE_NUMBER_IAQ_MEASURE,
     .duration_us = 50000,
-    .signals = SGP_PROFILE_IAQ_MEASURE_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_SIGNALS),
+    .number_of_signals = 1,
     .command = 0x2008,
-    .name = "iaq_measure",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
     .duration_us = 10000,
-    .signals = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
+    .number_of_signals = 1,
     .command = 0x2015,
-    .name = "iaq_get_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x201e,
-    .name = "iaq_set_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE = {
     .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
     .duration_us = 10000,
-    .signals = SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_GET_BASELINE_SIGNALS),
+    .number_of_signals = 1,
     .command = 0x20b3,
-    .name = "iaq_get_tvoc_inceptive_baseline",
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_ETOH_SIGNAL = {
     .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 50000,
-    .signals = SGP_PROFILE_MEASURE_ETOH_SIGNAL_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_MEASURE_ETOH_SIGNAL_SIGNALS),
+    .number_of_signals = 1,
     .command = 0x204d,
-    .name = "measure_etoh_signal",
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE_RAW = {
     .number = PROFILE_IAQ_MEASURE_RAW,
     .duration_us = 50000,
-    .signals = SGP_PROFILE_IAQ_MEASURE_RAW_SIGNALS,
-    .number_of_signals = ARRAY_SIZE(SGP_PROFILE_IAQ_MEASURE_RAW_SIGNALS),
+    .number_of_signals = 2,
     .command = 0x2046,
-    .name = "iaq_measure_raw",
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
     .number = PROFILE_SET_ABSOLUTE_HUMIDITY,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x2061,
-    .name = "set_absolute_humidity",
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_POWER_MODE = {
     .number = PROFILE_SET_POWER_MODE,
     .duration_us = 10000,
-    .signals = NULL,
     .number_of_signals = 0,
     .command = 0x209f,
-    .name = "set_power_mode",
 };
 
 static const struct sgp_profile *sgp_profiles_fs4[] = {

--- a/sgpc3/sgpc3_featureset.c
+++ b/sgpc3/sgpc3_featureset.c
@@ -55,94 +55,94 @@ const uint8_t PROFILE_NUMBER_SET_ABSOLUTE_HUMIDITY =
 const uint8_t PROFILE_NUMBER_SET_POWER_MODE = PROFILE_SET_POWER_MODE;
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT64 = {
-    .number = PROFILE_IAQ_INIT64,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2003,
+    .number = PROFILE_IAQ_INIT64,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT0 = {
-    .number = PROFILE_IAQ_INIT0,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2089,
+    .number = PROFILE_IAQ_INIT0,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT16 = {
-    .number = PROFILE_IAQ_INIT16,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2024,
+    .number = PROFILE_IAQ_INIT16,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT184 = {
-    .number = PROFILE_IAQ_INIT184,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x206a,
+    .number = PROFILE_IAQ_INIT184,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_INIT_CONTINUOUS = {
-    .number = PROFILE_IAQ_INIT_CONTINUOUS,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x20ae,
+    .number = PROFILE_IAQ_INIT_CONTINUOUS,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE = {
-    .number = PROFILE_NUMBER_IAQ_MEASURE,
     .duration_us = 50000,
     .number_of_signals = 1,
     .command = 0x2008,
+    .number = PROFILE_NUMBER_IAQ_MEASURE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 1,
     .command = 0x2015,
+    .number = PROFILE_NUMBER_IAQ_GET_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_SET_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x201e,
+    .number = PROFILE_NUMBER_IAQ_SET_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_GET_TVOC_INCEPTIVE_BASELINE = {
-    .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
     .duration_us = 10000,
     .number_of_signals = 1,
     .command = 0x20b3,
+    .number = PROFILE_NUMBER_IAQ_GET_TVOC_INCEPTIVE_BASELINE,
 };
 
 static const struct sgp_profile SGP_PROFILE_MEASURE_ETOH_SIGNAL = {
-    .number = PROFILE_NUMBER_RAW_SIGNALS,
     .duration_us = 50000,
     .number_of_signals = 1,
     .command = 0x204d,
+    .number = PROFILE_NUMBER_RAW_SIGNALS,
 };
 
 static const struct sgp_profile SGP_PROFILE_IAQ_MEASURE_RAW = {
-    .number = PROFILE_IAQ_MEASURE_RAW,
     .duration_us = 50000,
     .number_of_signals = 2,
     .command = 0x2046,
+    .number = PROFILE_IAQ_MEASURE_RAW,
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_ABSOLUTE_HUMIDITY = {
-    .number = PROFILE_SET_ABSOLUTE_HUMIDITY,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x2061,
+    .number = PROFILE_SET_ABSOLUTE_HUMIDITY,
 };
 
 static const struct sgp_profile SGP_PROFILE_SET_POWER_MODE = {
-    .number = PROFILE_SET_POWER_MODE,
     .duration_us = 10000,
     .number_of_signals = 0,
     .command = 0x209f,
+    .number = PROFILE_SET_POWER_MODE,
 };
 
 static const struct sgp_profile *sgp_profiles_fs4[] = {

--- a/sgpc3/user_config.inc
+++ b/sgpc3/user_config.inc
@@ -1,0 +1,26 @@
+## This file controls the custom user build settings.
+
+## Choose either of hw_i2c or sw_i2c depending on whether you have a dedicated
+## i2c controller (hw_i2c) or are using bit-banging on GPIOs (sw_i2c)
+# CONFIG_I2C_TYPE = hw_i2c
+
+## For hw_i2c, configure the i2c HAL implementation to use.
+## Use one of the available sample-implementations or implement your own using
+## the stub.
+# hw_i2c_impl_src = ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+## For sw_i2c, configure the GPIO implementation.
+# sw_i2c_impl_src = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+
+##
+## The items below are listed as documentation but may not need customization
+##
+
+## The build paths can also be changed here if needed
+# sgp_driver_dir = ..
+# sensirion_common_dir = ${sgp_driver_dir}/embedded-common
+# sgp_common_dir = ${sgp_driver_dir}/sgp-common
+# sgpc3_dir = ${sgp_driver_dir}/sgpc3
+
+## If you need different CFLAGS, those can be customized as well
+# CFLAGS = -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC

--- a/svm30/Makefile
+++ b/svm30/Makefile
@@ -1,52 +1,13 @@
-sht_source_dir := ../../embedded-sht/shtc1
-sht_common_dir := ../../embedded-sht/sht-common
-sht_sources := ${sht_source_dir}/shtc1.c ${sht_source_dir}/shtc1.h \
-               ${sht_common_dir}/sht_git_version.c ${sht_common_dir}/sht_git_version.h
+# See user_config.inc for build customization
+-include user_config.inc
+include default_config.inc
 
-sgp_source_dir := ../sgp30
-sgp_common_dir := ../sgp-common
-sgp_sources := ${sgp_source_dir}/sgp30_featureset.c \
-               ${sgp_common_dir}/sgp_featureset.h \
-               ${sgp_common_dir}/sgp_git_version.c ${sgp_common_dir}/sgp_git_version.h \
-               ${sgp_source_dir}/sgp30.c ${sgp_source_dir}/sgp30.h
+.PHONY: all clean
 
-sensirion_common_dir := ../embedded-common
-sensirion_common_sources := ${sensirion_common_dir}/sensirion_arch_config.h \
-                            ${sensirion_common_dir}/sensirion_i2c.h \
-                            ${sensirion_common_dir}/sensirion_common.c
+all: svm30_example_usage
 
-sw_i2c_dir := ${sensirion_common_dir}/sw_i2c
-hw_i2c_dir := ${sensirion_common_dir}/hw_i2c
-
-CFLAGS := -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 \
-          -I. -I${sensirion_common_dir} -I${sgp_source_dir} \
-          -I${sgp_common_dir} -I${sht_source_dir} -I${sht_common_dir}
-
-svm30_binaries := svm30_example_usage_hw_i2c svm30_example_usage_sw_i2c
-svm_binaries += ${svm30_binaries}
-svm_sources := svm30.c svm30.h
-
-sw_objects := sensirion_sw_i2c.o sensirion_sw_i2c_implementation.o
-hw_objects := sensirion_hw_i2c_implementation.o
-all_objects := ${hw_objects} ${sw_objects}
-
-.PHONY: all
-
-all: ${svm_binaries}
-
-sensirion_sw_i2c_implementation.o: ${sw_i2c_dir}/sensirion_sw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-sensirion_hw_i2c_implementation.o: ${hw_i2c_dir}/sensirion_hw_i2c_implementation.c
-	$(CC) $(CFLAGS) -c -o $@ $^
-
-sensirion_sw_i2c.o: ${sw_i2c_dir}/sensirion_sw_i2c.c
-	$(CC) -I${sw_i2c_dir} $(CFLAGS) -c -o $@ $^
-
-svm30_example_usage_hw_i2c: ${hw_objects} ${sensirion_common_sources} ${sgp_sources} ${sht_sources} ${svm_sources} svm30_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
-
-svm30_example_usage_sw_i2c: ${sw_objects} ${sensirion_common_sources} ${sgp_sources} ${sht_sources} ${svm_sources} svm30_example_usage.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
+svm30_example_usage: clean
+	$(CC) $(CFLAGS) -o $@ ${svm30_sources} ${${CONFIG_I2C_TYPE}_sources} ${svm30_dir}/svm30_example_usage.c
 
 clean:
-	$(RM) ${all_objects} ${svm_binaries}
+	$(RM) svm30_example_usage

--- a/svm30/default_config.inc
+++ b/svm30/default_config.inc
@@ -1,0 +1,42 @@
+sgp_driver_dir ?= ..
+sht_driver_dir ?= ${sgp_driver_dir}/../embedded-sht
+sensirion_common_dir ?= ${sgp_driver_dir}/embedded-common
+sgp_common_dir ?= ${sgp_driver_dir}/sgp-common
+sgp30_dir ?= ${sgp_driver_dir}/sgp30
+svm30_dir ?= ${sgp_driver_dir}/svm30
+sht_common_dir ?= ${sht_driver_dir}/sht-common
+shtc1_dir ?= ${sht_driver_dir}/shtc1
+CONFIG_I2C_TYPE ?= hw_i2c
+
+sw_i2c_impl_src ?= ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+hw_i2c_impl_src ?= ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+CFLAGS ?= -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC
+CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgp30_dir} \
+          -I${sht_common_dir} -I${shtc1_dir} -I${svm30_dir} \
+          -I${sensirion_common_dir}/${CONFIG_I2C_TYPE}
+
+sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
+                           ${sensirion_common_dir}/sensirion_i2c.h \
+			   ${sensirion_common_dir}/sensirion_common.h \
+			   ${sensirion_common_dir}/sensirion_common.c
+
+sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
+                     ${sgp_common_dir}/sgp_git_version.c \
+		     ${sgp_common_dir}/sgp_featureset.h
+
+sgp30_sources = ${sgp30_dir}/sgp30_featureset.c \
+		${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
+
+sht_common_sources = ${sht_common_dir}/sht_git_version.h \
+		     ${sht_common_dir}/sht_git_version.c
+
+shtc1_sources = ${shtc1_dir}/shtc1.h ${shtc1_dir}/shtc1.c
+
+svm30_sources = ${sensirion_common_sources} ${sgp_common_sources} ${sht_common_sources} \
+		${sgp30_sources} ${shtc1_sources} ${svm30_dir}/svm30.h ${svm30_dir}/svm30.c
+
+hw_i2c_sources = ${hw_i2c_impl_src}
+sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
+		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+		 ${sw_i2c_impl_src}

--- a/svm30/user_config.inc
+++ b/svm30/user_config.inc
@@ -1,0 +1,29 @@
+## This file controls the custom user build settings.
+
+## Choose either of hw_i2c or sw_i2c depending on whether you have a dedicated
+## i2c controller (hw_i2c) or are using bit-banging on GPIOs (sw_i2c)
+# CONFIG_I2C_TYPE = hw_i2c
+
+## For hw_i2c, configure the i2c HAL implementation to use.
+## Use one of the available sample-implementations or implement your own using
+## the stub.
+# hw_i2c_impl_src = ${sensirion_common_dir}/hw_i2c/sensirion_hw_i2c_implementation.c
+
+## For sw_i2c, configure the GPIO implementation.
+# sw_i2c_impl_src = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_implementation.c
+
+##
+## The items below are listed as documentation but may not need customization
+##
+
+## The build paths can also be changed here if needed
+# sgp_driver_dir = ..
+# sht_driver_dir = ${sgp_driver_dir}/../embedded-sht
+# sensirion_common_dir = ${sgp_driver_dir}/embedded-common
+# sgp_common_dir = ${sgp_driver_dir}/sgp-common
+# svm30_dir = ${sgp_driver_dir}/svm30
+# sht_common_dir = ${sht_driver_dir}/sht-common
+# shtc1_dir = ${sht_driver_dir}/shtc1
+
+## If you need different CFLAGS, those can be customized as well
+# CFLAGS = -Os -Wall -fstrict-aliasing -Wstrict-aliasing=1 -Wsign-conversion -fPIC


### PR DESCRIPTION
Instead of compiling the different source files into object files
and then linking those, we switch to compiling the binaries in a
single go. This fixes some dependency tracking issues. Speed is not
an issue since the files are relatively small.

Additional changes:
 * We also split out the build congifs (path and CFLAGS) into a
   default_config.inc and user_config.inc file that are included
   from the main Makefile.
   The `user_config.inc` file serves as a documentation as all lines
   are commented out. It's still part of .gitignore, so that changes
   aren't picked up by default.

 * Only one i2c type is built from the `all` target (depending on
   `CONFIG_I2C_TYPE`).

 * The user has the option of providing a custom `user_config.inc`
   to further customize the build.

 * Updated circle CI script to build both the empty stubs and the
   Linux user space sample implementation for both hw_i2c and
   sw_i2c.