### PR TITLE
Fix whitespace in default_config.inc

### DIFF
--- a/sgp30/default_config.inc
+++ b/sgp30/default_config.inc
@@ -13,18 +13,19 @@ CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgp30_dir} \
 
 sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
                            ${sensirion_common_dir}/sensirion_i2c.h \
-			   ${sensirion_common_dir}/sensirion_common.h \
-			   ${sensirion_common_dir}/sensirion_common.c
+                           ${sensirion_common_dir}/sensirion_common.h \
+                           ${sensirion_common_dir}/sensirion_common.c
 
 sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
                      ${sgp_common_dir}/sgp_git_version.c \
-		     ${sgp_common_dir}/sgp_featureset.h
+                     ${sgp_common_dir}/sgp_featureset.h
 
-sgp30_sources = ${sensirion_common_sources} ${sgp_common_sources} \
-		${sgp30_dir}/sgp30_featureset.c \
-		${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
+sgp30_sources = ${sensirion_common_sources} \
+                ${sgp_common_sources} \
+                ${sgp30_dir}/sgp30_featureset.c \
+                ${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
 
 hw_i2c_sources = ${hw_i2c_impl_src}
 sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
-		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
-		 ${sw_i2c_impl_src}
+                 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+                 ${sw_i2c_impl_src}

--- a/sgpc3/default_config.inc
+++ b/sgpc3/default_config.inc
@@ -13,18 +13,18 @@ CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgpc3_dir} \
 
 sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
                            ${sensirion_common_dir}/sensirion_i2c.h \
-			   ${sensirion_common_dir}/sensirion_common.h \
-			   ${sensirion_common_dir}/sensirion_common.c
+                           ${sensirion_common_dir}/sensirion_common.h \
+                           ${sensirion_common_dir}/sensirion_common.c
 
 sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
                      ${sgp_common_dir}/sgp_git_version.c \
-		     ${sgp_common_dir}/sgp_featureset.h
+                     ${sgp_common_dir}/sgp_featureset.h
 
 sgpc3_sources = ${sensirion_common_sources} ${sgp_common_sources} \
-		${sgpc3_dir}/sgpc3_featureset.c \
-		${sgpc3_dir}/sgpc3.h ${sgpc3_dir}/sgpc3.c
+                ${sgpc3_dir}/sgpc3_featureset.c \
+                ${sgpc3_dir}/sgpc3.h ${sgpc3_dir}/sgpc3.c
 
 hw_i2c_sources = ${hw_i2c_impl_src}
 sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
-		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
-		 ${sw_i2c_impl_src}
+                 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+                 ${sw_i2c_impl_src}

--- a/svm30/default_config.inc
+++ b/svm30/default_config.inc
@@ -18,25 +18,29 @@ CFLAGS += -I${sensirion_common_dir} -I${sgp_common_dir} -I${sgp30_dir} \
 
 sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
                            ${sensirion_common_dir}/sensirion_i2c.h \
-			   ${sensirion_common_dir}/sensirion_common.h \
-			   ${sensirion_common_dir}/sensirion_common.c
+                           ${sensirion_common_dir}/sensirion_common.h \
+                           ${sensirion_common_dir}/sensirion_common.c
 
 sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
                      ${sgp_common_dir}/sgp_git_version.c \
-		     ${sgp_common_dir}/sgp_featureset.h
+                     ${sgp_common_dir}/sgp_featureset.h
 
 sgp30_sources = ${sgp30_dir}/sgp30_featureset.c \
-		${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
+                ${sgp30_dir}/sgp30.h ${sgp30_dir}/sgp30.c
 
 sht_common_sources = ${sht_common_dir}/sht_git_version.h \
-		     ${sht_common_dir}/sht_git_version.c
+                     ${sht_common_dir}/sht_git_version.c
 
 shtc1_sources = ${shtc1_dir}/shtc1.h ${shtc1_dir}/shtc1.c
 
-svm30_sources = ${sensirion_common_sources} ${sgp_common_sources} ${sht_common_sources} \
-		${sgp30_sources} ${shtc1_sources} ${svm30_dir}/svm30.h ${svm30_dir}/svm30.c
+svm30_sources = ${sensirion_common_sources} \
+                ${sgp_common_sources} \
+                ${sht_common_sources} \
+                ${sgp30_sources} \
+                ${shtc1_sources} \
+                ${svm30_dir}/svm30.h ${svm30_dir}/svm30.c
 
 hw_i2c_sources = ${hw_i2c_impl_src}
 sw_i2c_sources = ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c_gpio.h \
-		 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
-		 ${sw_i2c_impl_src}
+                 ${sensirion_common_dir}/sw_i2c/sensirion_sw_i2c.c \
+                 ${sw_i2c_impl_src}


### PR DESCRIPTION
Fix whitespace errors and consistently use spaces instead of tabs.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
