### PR TITLE
SVM30: Fix absolute humidity at very low temperatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [`added`]   Add error codes `SGP30_ERR_INVALID_PRODUCT_TYPE` and
               `SGPC3_ERR_INVALID_PRODUCT_TYPE` to SGP30 and SGPC3 drivers,
               respectively.
+* [`fixed`]   SVM30: Fix calculation of absolute humidity at very low
+              temperatures (< -20°C / -4°F). The conversion now bounds the
+              result to the lowest result from the look-up table.
+              Also become tolerant towards accepting negative %RH values.
 
 ## [5.0.0] - 2019-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
               temperatures (< -20°C / -4°F). The conversion now bounds the
               result to the lowest result from the look-up table.
               Also become tolerant towards accepting negative %RH values.
+* [`fixed`]   SVM30: Fix disabling of humidity compensation at values < 0.08%RH
 
 ## [5.0.0] - 2019-05-17
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release/svm30: release/sgp30
 	cp svm30/Makefile $${pkgdir} && \
 	cp svm30/*.[ch] $${pkgdir} && \
 	cp svm30/default_config.inc $${pkgdir} && \
-	for i in sensirion_common_dir sgp_common_dir sht_common_dir sgp30_dir shtc1_dir svm30_dir; \
+	for i in $${driver}_dir sgp_driver_dir sht_driver_dir sensirion_common_dir sgp_common_dir sht_common_dir sgp30_dir shtc1_dir; \
 		do echo "$$i = ." >> $${pkgdir}/user_config.inc; \
 	done && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \

--- a/svm30/svm30.c
+++ b/svm30/svm30.c
@@ -88,26 +88,33 @@ static uint32_t sensirion_calc_absolute_humidity(const int32_t *temperature,
     return ((ret >> 3) * (uint32_t)(*humidity)) / 12500;
 }
 
+static int16_t svm_set_humidity(const int32_t *temperature,
+                                const int32_t *humidity) {
+    uint32_t absolute_humidity;
+
+    absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
+
+    if (absolute_humidity == 0)
+        absolute_humidity = 1; /* avoid disabling humidity compensation */
+
+    return sgp30_set_absolute_humidity(absolute_humidity);
+}
+
 const char *svm_get_driver_version() {
     return SGP_DRV_VERSION_STR;
 }
 
 int16_t svm_measure_iaq_blocking_read(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm,
                                       int32_t *temperature, int32_t *humidity) {
-    uint32_t absolute_humidity;
-    uint16_t sgp_feature_set;
-    uint8_t sgp_product_type;
     int16_t err;
 
     err = shtc1_measure_blocking_read(temperature, humidity);
     if (err != STATUS_OK)
         return err;
 
-    sgp30_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
-    absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
-    if (absolute_humidity == 0)
-        absolute_humidity = 1; /* avoid disabling humidity compensation */
-    sgp30_set_absolute_humidity(absolute_humidity);
+    err = svm_set_humidity(temperature, humidity);
+    if (err != STATUS_OK)
+        return err;
 
     svm_compensate_rht(temperature, humidity);
 
@@ -121,18 +128,15 @@ int16_t svm_measure_iaq_blocking_read(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm,
 int16_t svm_measure_raw_blocking_read(uint16_t *ethanol_raw_signal,
                                       uint16_t *h2_raw_signal,
                                       int32_t *temperature, int32_t *humidity) {
-    uint32_t absolute_humidity;
-    uint16_t sgp_feature_set;
-    uint8_t sgp_product_type;
     int16_t err;
 
     err = shtc1_measure_blocking_read(temperature, humidity);
     if (err != STATUS_OK)
         return err;
 
-    sgp30_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
-    absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
-    sgp30_set_absolute_humidity(absolute_humidity);
+    err = svm_set_humidity(temperature, humidity);
+    if (err != STATUS_OK)
+        return err;
 
     err = sgp30_measure_raw_blocking_read(ethanol_raw_signal, h2_raw_signal);
     if (err != STATUS_OK)

--- a/svm30/svm30.c
+++ b/svm30/svm30.c
@@ -54,11 +54,16 @@ static uint32_t sensirion_calc_absolute_humidity(const int32_t *temperature,
                                                  const int32_t *humidity) {
     uint32_t t, i, rem, norm_humi, ret;
 
-    if (*humidity == 0)
+    if (*humidity <= 0)
         return 0;
 
     norm_humi = ((uint32_t)*humidity * 82) >> 13;
-    t = *temperature - T_LO;
+
+    if (*temperature < T_LO)
+        t = 0;
+    else
+        t = (uint32_t)(*temperature - T_LO);
+
     i = t / T_STEP;
     rem = t % T_STEP;
 

--- a/svm30/svm30.c
+++ b/svm30/svm30.c
@@ -97,6 +97,8 @@ int16_t svm_measure_iaq_blocking_read(uint16_t *tvoc_ppb, uint16_t *co2_eq_ppm,
 
     sgp30_get_feature_set_version(&sgp_feature_set, &sgp_product_type);
     absolute_humidity = sensirion_calc_absolute_humidity(temperature, humidity);
+    if (absolute_humidity == 0)
+        absolute_humidity = 1; /* avoid disabling humidity compensation */
     sgp30_set_absolute_humidity(absolute_humidity);
 
     svm_compensate_rht(temperature, humidity);


### PR DESCRIPTION
* At very low temperatures (< -20°C / -4°F), the RH->AH conversion
  overflowed and was thus wrong. The conversion now bounds the result
  to the lowest result from the look-up table.
* Become tolerant towards accepting negative %RH values.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
