### PR TITLE
Makefile: only specify driver dir in release config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ $(release_drivers): sgp-common/sgp_git_version.c
 	cp -r $${driver}/* "$${pkgdir}" && \
 	echo 'sensirion_common_dir = .' >> $${pkgdir}/user_config.inc && \
 	echo 'sgp_common_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'sgp30_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'sgpc3_dir = .' >> $${pkgdir}/user_config.inc && \
-	echo 'svm30_dir = .' >> $${pkgdir}/user_config.inc && \
+	echo "$${driver}_dir = ." >> $${pkgdir}/user_config.inc && \
 	cd "$${pkgdir}" && $(MAKE) $(MFLAGS) && $(MAKE) clean $(MFLAGS) && cd - && \
 	cd release && zip -r "$${pkgname}.zip" "$${pkgname}" && cd - && \
 	ln -sf $${pkgname} $@


### PR DESCRIPTION
When building the release, only specify the variable for the current driver

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
