### PR TITLE
SGP30: Update timings according to datasheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [`fixed`]   SVM30: Fix disabling of humidity compensation at values < 0.08%RH
 * [`changed`] SVM30: Better approximation error when calculating absolute
               humidity from relative humidity and temperature
+* [`fixed`]   SGP30: Adjust timings according to datasheet
 
 ## [5.0.0] - 2019-05-17
 

--- a/sgp30/sgp30.c
+++ b/sgp30/sgp30.c
@@ -45,7 +45,7 @@ static const uint8_t SGP30_I2C_ADDRESS = 0x58;
 
 /* command and constants for reading the featureset version */
 #define SGP30_CMD_GET_FEATURESET 0x202f
-#define SGP30_CMD_GET_FEATURESET_DURATION_US 1000
+#define SGP30_CMD_GET_FEATURESET_DURATION_US 10000
 #define SGP30_CMD_GET_FEATURESET_WORDS 1
 
 /* command and constants for on-chip self-test */
@@ -60,7 +60,7 @@ static const uint8_t SGP30_I2C_ADDRESS = 0x58;
 
 /* command and constants for IAQ measure */
 #define SGP30_CMD_IAQ_MEASURE 0x2008
-#define SGP30_CMD_IAQ_MEASURE_DURATION_US 50000
+#define SGP30_CMD_IAQ_MEASURE_DURATION_US 12000
 #define SGP30_CMD_IAQ_MEASURE_WORDS 2
 
 /* command and constants for getting IAQ baseline */


### PR DESCRIPTION
Two changes to update the timings against the datasheet:
  https://www.sensirion.com/file/datasheet_sgp30

* Slow down the timing for retrieving the featureset
  from 1ms (typical time) to 10ms (max time).
* Speed up the timing for retrieving the IAQ values
  from 50ms to 12ms.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
