### PR TITLE
Fix typo in header guard

### DIFF
--- a/sgp-common/sgp_git_version.h
+++ b/sgp-common/sgp_git_version.h
@@ -29,9 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GIT_VERSION_H
-#define GIT_VERSION_H
+#ifndef SGP_GIT_VERSION_H
+#define SGP_GIT_VERSION_H
 
 extern const char *SGP_DRV_VERSION_STR;
 
-#endif /* GIT_VERSION_H */
+#endif /* SGP_GIT_VERSION_H */


### PR DESCRIPTION
Now called SGP_GIT_VERSION_H instead of just GIT_VERSION_H

Check the following:

 - [ ] ~~Breaking changes marked in commit message~~
 - [ ] ~~Changelog updated~~
 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] ~~Tested on actual hardware~~
