### PR TITLE
Fix sgpc3_tvoc_init_no_preheat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [`fixed`]   Use correct command for `sgpc3_tvoc_init_no_preheat()`
+              The wrong command caused a preheating of 16s.
+
 ## [6.0.0] - 2020-04-27
 
 * [`changed`] Move the i2c init call out of `probe()` and into the examples

--- a/sgpc3/sgpc3.c
+++ b/sgpc3/sgpc3.c
@@ -55,7 +55,7 @@ static const uint8_t SGPC3_I2C_ADDRESS = 0x58;
 #define SGPC3_CMD_MEASURE_TEST_OK 0xd400
 
 /* command and constants for IAQ init 0 */
-#define SGPC3_CMD_IAQ_INIT_0 0x2024
+#define SGPC3_CMD_IAQ_INIT_0 0x2089
 #define SGPC3_CMD_IAQ_INIT_0_DURATION_US 10000
 
 /* command and constants for IAQ init 64 */


### PR DESCRIPTION
Check the following:

 - [x] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
