### PR TITLE
Fix example files to print by default

### DIFF
--- a/sgpc3_with_shtc1/sgpc3_with_shtc1_example_usage.c
+++ b/sgpc3_with_shtc1/sgpc3_with_shtc1_example_usage.c
@@ -31,11 +31,11 @@
 
 #include "sgpc3_with_shtc1.h"
 
-/* TO USE CONSOLE OUTPUT (printf) AND WAIT (sleep) PLEASE ADAPT THEM TO YOUR
- * PLATFORM.
- *
- * #include <stdio.h> // printf
- * #include <unistd.h> // sleep
+#include <stdio.h>  // printf
+
+/* TO USE CONSOLE OUTPUT (printf) YOU MAY NEED TO ADAPT THE
+ * INCLUDE ABOVE OR DEFINE IT ACCORDING TO YOUR PLATFORM.
+ * #define printf(...)
  */
 
 int main(void) {
@@ -51,10 +51,10 @@ int main(void) {
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
     while (sgpc3_with_shtc1_probe() != STATUS_OK) {
-        /* printf("Failed to detect SGPC3 and/or SHTC1\n"); */
+        printf("Failed to detect SGPC3 and/or SHTC1\n");
         sensirion_sleep_usec(1000000);  // wait 1s before trying again
     }
-    /* printf("SGPC3 and SHTC1 sensors detected\n"); */
+    printf("SGPC3 and SHTC1 sensors detected\n");
 
     /* Consider the two cases (A) and (B):
      * (A) If no baseline is available or the most recent baseline is more than
@@ -73,12 +73,12 @@ int main(void) {
         err = sgpc3_with_shtc1_measure_iaq_blocking_read(
             &tvoc_ppb, &temperature, &humidity);
         if (err == STATUS_OK) {
-            /* printf("tVOC  Concentration: %dppb\n", tvoc_ppb);
-             * printf("Temperature: %0.3fC\n", temperature / 1000.0f);
-             * printf("Humidity: %0.3f%%RH\n", humidity / 1000.0f);
-             */
+            printf("tVOC  Concentration: %dppb\n", tvoc_ppb);
+            printf("Temperature: %0.3fC\n", temperature / 1000.0f);
+            printf("Humidity: %0.3f%%RH\n", humidity / 1000.0f);
+
         } else {
-            /* printf("error reading sensor\n"); */
+            printf("error reading sensor\n");
         }
 
         /* Persist the current baseline every hour */

--- a/svm30/svm30_example_usage.c
+++ b/svm30/svm30_example_usage.c
@@ -31,11 +31,11 @@
 
 #include "svm30.h"
 
-/* TO USE CONSOLE OUTPUT (printf) AND WAIT (sleep) PLEASE ADAPT THEM TO YOUR
- * PLATFORM.
- *
- * #include <stdio.h> // printf
- * #include <unistd.h> // sleep
+#include <stdio.h>  // printf
+
+/* TO USE CONSOLE OUTPUT (printf) YOU MAY NEED TO ADAPT THE
+ * INCLUDE ABOVE OR DEFINE IT ACCORDING TO YOUR PLATFORM.
+ * #define printf(...)
  */
 
 int main(void) {
@@ -51,9 +51,9 @@ int main(void) {
     /* Busy loop for initialization. The main loop does not work without
      * a sensor. */
     while (svm_probe() != STATUS_OK) {
-        /* printf("SVM30 module probing failed\n"); */
+        printf("SVM30 module probing failed\n");
     }
-    /* printf("SVM30 module probing successful\n"); */
+    printf("SVM30 module probing successful\n");
 
     /* Consider the two cases (A) and (B):
      * (A) If no baseline is available or the most recent baseline is more than
@@ -71,13 +71,13 @@ int main(void) {
         err = svm_measure_iaq_blocking_read(&tvoc_ppb, &co2_eq_ppm,
                                             &temperature, &humidity);
         if (err == STATUS_OK) {
-            /* printf("tVOC  Concentration: %dppb\n", tvoc_ppb);
-             * printf("CO2eq Concentration: %dppm\n", co2_eq_ppm);
-             * printf("Temperature: %0.3fC\n", temperature / 1000.0f);
-             * printf("Humidity: %0.3f%%RH\n", humidity / 1000.0f);
-             */
+            printf("tVOC  Concentration: %dppb\n", tvoc_ppb);
+            printf("CO2eq Concentration: %dppm\n", co2_eq_ppm);
+            printf("Temperature: %0.3fC\n", temperature / 1000.0f);
+            printf("Humidity: %0.3f%%RH\n", humidity / 1000.0f);
+
         } else {
-            /* printf("error reading sensor\n"); */
+            printf("error reading sensor\n");
         }
 
         /* Persist the current baseline every hour */
@@ -91,7 +91,7 @@ int main(void) {
         /* The IAQ measurement must be triggered exactly once per second (SGP30)
          * to get accurate values.
          */
-        /* sleep(1); // SVM30 / SGP30 */
+        sensirion_sleep_usec(1000000);  // SVM30 / SGP30
     }
     return 0;
 }


### PR DESCRIPTION
    - Uncommment printf and sleep from sgpc3_with_shtc1_example_usage.c
      file so by default it prints out status messages.
    - Uncommment printf and sleep from svm30_example_usage.c
      file so by default it prints out status messages.

Check the following:

 - [na] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
