### PR TITLE
Change Makefile to only include needed part of embedded-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * [`fixed`]   Arduino: Initialize serial port and Wait for it to be ready.
+* [`changed`] Makefile to only include needed files from embedded-common
+
 
 ## [7.0.0] - 2020-09-01
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ $(release_drivers): prepare
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-common/* "$${pkgdir}" && \
+	cp -r embedded-common/hw_i2c/ "$${pkgdir}" && \
+	cp -r embedded-common/sw_i2c/ "$${pkgdir}" && \
+	cp embedded-common/sensirion_arch_config.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.c "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_i2c.h "$${pkgdir}" && \
 	cp -r sgp-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \
@@ -50,7 +55,14 @@ release/sgp40: prepare docs
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-common/* "$${pkgdir}" && \
+	cp -r embedded-common/hw_i2c/ "$${pkgdir}" && \
+	cp -r embedded-common/sw_i2c/ "$${pkgdir}" && \
+	cp embedded-common/LICENSE "$${pkgdir}" && \
+	cp embedded-common/sensirion_arch_config.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.c "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_i2c.h "$${pkgdir}" && \
+	cp embedded-common/README.md "$${pkgdir}" && \
 	cp -r sgp-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp docs/Application_Note_SGP40.pdf $${pkgdir} && \


### PR DESCRIPTION
Change Makefile to include only needed part of embedded-common in the
release.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [na] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
