### PR TITLE
Make definition of sgp40_sources consistent 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [`changed`] default_config.inc for sgp40_voc_index such that the variable
+              sgp40_sources matches the one named the same in sgp40.
 * [`fixed`]   Arduino: Initialize serial port and Wait for it to be ready.
 * [`changed`] Makefile to only include needed files from embedded-common
 

--- a/sgp40_voc_index/default_config.inc
+++ b/sgp40_voc_index/default_config.inc
@@ -27,15 +27,15 @@ sensirion_common_sources = ${sensirion_common_dir}/sensirion_arch_config.h \
 sgp_common_sources = ${sgp_common_dir}/sgp_git_version.h \
                      ${sgp_common_dir}/sgp_git_version.c
 
-sgp40_sources = ${sgp40_dir}/sgp40.h ${sgp40_dir}/sgp40.c
+sgp40_sources = ${sensirion_common_sources} \
+                ${sgp_common_sources} \
+                ${sgp40_dir}/sgp40.h ${sgp40_dir}/sgp40.c
 
 sgp40_voc_index_voc_algorithm_sources = ${sgp40_voc_index_voc_algorithm_dir}/sensirion_voc_algorithm.h \
                                      ${sgp40_voc_index_voc_algorithm_dir}/sensirion_voc_algorithm.c
 
-sgp40_voc_index_sources = ${sensirion_common_sources} \
-                        ${sgp_common_sources} \
+sgp40_voc_index_sources = ${sgp40_sources} \
                         ${sht_common_sources} \
-                        ${sgp40_sources} \
                         ${shtc1_sources} \
                         ${sgp40_voc_index_voc_algorithm_sources} \
                         ${sgp40_voc_index_dir}/sgp40_voc_index.h \


### PR DESCRIPTION
The sgp40_sources variable was defined differently in the default
config of the sgp40 and the sgp40_voc_index part of this repo.
This is normally not a problem but in the test's Makefile both
configs are included and now the order of the includes is relevant.
If the sgp40 config was included last nothing happened but the other
way around the compilation of the sgp40 was missing the sensirion
common and the sgp common files and failed. This was not the case
in the master branch but an internal one, where the includes happened
to added in the wrong order.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
