### PR TITLE
Replace i2c_reset calls with sensirion_i2c_general_call_reset

### DIFF
--- a/tests/sgp30-test.cpp
+++ b/tests/sgp30-test.cpp
@@ -162,8 +162,8 @@ static void test_setup() {
 }
 
 static void test_teardown() {
-    int16_t ret = i2c_reset();
-    CHECK_ZERO_TEXT(ret, "i2c_reset");
+    int16_t ret = sensirion_i2c_general_call_reset();
+    CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
     sensirion_i2c_release();
 }
 

--- a/tests/sgp40-test.cpp
+++ b/tests/sgp40-test.cpp
@@ -18,8 +18,8 @@ TEST_GROUP (SGP40_Tests) {
     }
 
     void teardown() {
-        int16_t ret = i2c_reset();
-        CHECK_ZERO_TEXT(ret, "i2c_reset");
+        int16_t ret = sensirion_i2c_general_call_reset();
+        CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
         sensirion_i2c_release();
     }
 };

--- a/tests/sgp40-voc-index-test.cpp
+++ b/tests/sgp40-voc-index-test.cpp
@@ -21,8 +21,8 @@ TEST_GROUP (SGP40_VOC_INDEX_Tests) {
     }
 
     void teardown() {
-        int16_t ret = i2c_reset();
-        CHECK_ZERO_TEXT(ret, "i2c_reset");
+        int16_t ret = sensirion_i2c_general_call_reset();
+        CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
         sensirion_i2c_release();
     }
 };

--- a/tests/sgpc3-test.cpp
+++ b/tests/sgpc3-test.cpp
@@ -168,8 +168,8 @@ static void sgpc3_test_all_inits(uint16_t expected_feature_set) {
 }
 
 static void test_teardown() {
-    int16_t ret = i2c_reset();
-    CHECK_ZERO_TEXT(ret, "i2c_reset");
+    int16_t ret = sensirion_i2c_general_call_reset();
+    CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
     sensirion_i2c_release();
 }
 

--- a/tests/svm30-test.cpp
+++ b/tests/svm30-test.cpp
@@ -29,8 +29,8 @@ TEST_GROUP (SVM30_Tests) {
     }
 
     void teardown() {
-        int16_t ret = i2c_reset();
-        CHECK_ZERO_TEXT(ret, "i2c_reset");
+        int16_t ret = sensirion_i2c_general_call_reset();
+        CHECK_ZERO_TEXT(ret, "sensirion_i2c_general_call_reset");
         sensirion_i2c_release();
     }
 };


### PR DESCRIPTION
i2c_reset is deprecated and just calls into
sensirion_i2c_general_call_reset.

Check the following:

 - [na] Breaking changes marked in commit message
 - [na] Changelog updated
 - [X] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
