### PR TITLE
Fix fix16_mul() to work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [`fixed`]   Fix fix16_mul() to work properly with 8-bit PIC compilers (and
+              possibly others)
+
 ## [7.1.1] - 2020-12-14
 
 * [`changed`] Update embedded-common to 0.1.0 to improve compatibility when

--- a/sgp40_voc_index/sensirion_voc_algorithm.h
+++ b/sgp40_voc_index/sensirion_voc_algorithm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Sensirion AG
+ * Copyright (c) 2021, Sensirion AG
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,11 @@ typedef int32_t fix16_t;
 
 #define F16(x) \
     ((fix16_t)(((x) >= 0) ? ((x)*65536.0 + 0.5) : ((x)*65536.0 - 0.5)))
+
+// Should be set by the building toolchain
+#ifndef LIBRARY_VERSION_NAME
+#define LIBRARY_VERSION_NAME "custom build"
+#endif
 
 #define VocAlgorithm_SAMPLING_INTERVAL (1.)
 #define VocAlgorithm_INITIAL_BLACKOUT (45.)


### PR DESCRIPTION
* Affects 8-bit PIC compilers (and possibly others)

Check the following:

 - [ ] Breaking changes marked in commit message
 - [ ] Changelog updated
 - [ ] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
